### PR TITLE
Use tox for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,15 @@
 sudo: false
 language: python
 python:
-  - "2.7"
-  - "3.5"
+- "3.5"
+env:
+  global:
+  - PIP_RETRIES=10
+  - PIP_TIMEOUT=30
+  matrix:
+  - TOXENV=py27
+  - TOXENV=py35
 install:
-  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then pip install unittest2; fi
-  - pip install asgiref twisted autobahn
-script: if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then python -m unittest2; else python -m unittest; fi
+- travis_retry pip install tox
+script:
+- tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,18 @@
+[tox]
+envlist = py{27,35}
+
+[testenv]
+usedevelop = true
+commands =
+    python -m unittest
+deps =
+    asgiref
+    twisted
+    autobahn
+
+[testenv:py27]
+commands =
+    python -m unittest2
+deps =
+    unittest2
+    {[testenv]deps}


### PR DESCRIPTION
Makes it easier to run the test suite on various platforms with one command, and to reproduce the same build on travis and locally.

Could potentially enable pypy and pypy3 support.
