### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ daphne
     :target: https://pypi.python.org/pypi/daphne
 
 Daphne is a HTTP, HTTP2 and WebSocket protocol server for
-`ASGI <http://channels.readthedocs.org/en/latest/asgi.html>`_, and developed
+`ASGI <https://channels.readthedocs.io/en/latest/asgi.html>`_, and developed
 to power Django Channels.
 
 It supports automatic negotiation of protocols; there's no need for URL

--- a/daphne/tests/test_http.py
+++ b/daphne/tests/test_http.py
@@ -69,7 +69,7 @@ class TestHTTPProtocol(TestCase):
 
     def test_http_disconnect_sets_path_key(self):
         """
-        Tests http disconnect has the path key set, see http://channels.readthedocs.io/en/latest/asgi.html#disconnect
+        Tests http disconnect has the path key set, see https://channels.readthedocs.io/en/latest/asgi.html#disconnect
         """
         # Send a simple request to the protocol
         self.proto.dataReceived(


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.