### PR TITLE
Refactor for HTTP/2 support.

### DIFF
--- a/daphne/http_protocol.py
+++ b/daphne/http_protocol.py
@@ -5,7 +5,10 @@ import six
 import time
 import traceback
 
+from zope.interface import implementer
+
 from six.moves.urllib_parse import unquote, unquote_plus
+from twisted.internet.interfaces import IProtocolNegotiationFactory
 from twisted.protocols.policies import ProtocolWrapper
 from twisted.web import http
 
@@ -275,6 +278,7 @@ class WebRequest(http.Request):
         })
 
 
+@implementer(IProtocolNegotiationFactory)
 class HTTPFactory(http.HTTPFactory):
     """
     Factory which takes care of tracking which protocol
@@ -370,3 +374,18 @@ class HTTPFactory(http.HTTPFactory):
                 # Ping check
                 else:
                     protocol.check_ping()
+
+    # IProtocolNegotiationFactory
+    def acceptableProtocols(self):
+        """
+        Protocols this server can speak after ALPN negotiation. Currently that
+        is HTTP/1.1 and optionally HTTP/2. Websockets cannot be negotiated
+        using ALPN, so that doesn't go here: anyone wanting websockets will
+        negotiate HTTP/1.1 and then do the upgrade dance.
+        """
+        baseProtocols = [b'http/1.1']
+
+        if http.H2_ENABLED:
+            baseProtocols.insert(0, b'h2')
+
+        return baseProtocols


### PR DESCRIPTION
This PR refactors the internals of Daphne to enable basic HTTP/2 support. This does not enable any of the features for HTTP/2 defined in the ASGI specification, but simply allows for daphne to serve HTTP/2 requests directly without an intervening terminating proxy.

This patch does not work against the current Twisted: it relies on the fix for [Twisted issue 8909](https://twistedmatrix.com/trac/ticket/8909) landing (available in twisted/twisted#597). It will also never work on versions of Twisted before the one that lands that patch.

This fact, along with the fact that Twisted requires several optional dependencies to handle HTTP/2, raises a series of important questions:

1. Should daphne's minimum Twisted version be bumped to the one that supports HTTP/2 in Daphne? (I'd say yes).
2. Should daphne also install the Twisted `http2` extra?
3. What about the Twisted `tls` extra, also required for HTTP/2 and TLS support?

All things worth considering.