### PR TITLE
UnsupportedAddressFamily error when use file descriptor.

### DIFF
--- a/daphne/server.py
+++ b/daphne/server.py
@@ -1,9 +1,9 @@
 import logging
-import socket
+import warnings
 
 from twisted.internet import reactor, defer
-from twisted.logger import globalLogBeginner, STDLibLogObserver
 from twisted.internet.endpoints import serverFromString
+from twisted.logger import globalLogBeginner, STDLibLogObserver
 
 from .http_protocol import HTTPFactory
 
@@ -17,7 +17,7 @@ class Server(object):
         channel_layer,
         host=None,
         port=None,
-        endpoints=[],
+        endpoints=None,
         unix_socket=None,
         file_descriptor=None,
         signal_handlers=True,
@@ -33,12 +33,12 @@ class Server(object):
         verbosity=1
     ):
         self.channel_layer = channel_layer
-        self.endpoints = endpoints
+        self.endpoints = endpoints or []
 
         if any([host, port, unix_socket, file_descriptor]):
-            raise DeprecationWarning('''
+            warnings.warn('''
                 The host/port/unix_socket/file_descriptor keyword arguments to %s are deprecated.
-            ''' % self.__class__.__name__)
+            ''' % self.__class__.__name__, DeprecationWarning)
             # build endpoint description strings from deprecated kwargs
             self.endpoints = sorted(self.endpoints + build_endpoint_description_strings(
                 host=host,
@@ -193,12 +193,6 @@ def build_endpoint_description_strings(
         socket_descriptions.append('unix:%s' % unix_socket)
 
     if file_descriptor:
-        socket_descriptions.append('fd:domain=INET:fileno=%d' % int(file_descriptor))
+        socket_descriptions.append('fd:fileno=%d' % int(file_descriptor))
 
     return socket_descriptions
-
-
-
-
-
-

--- a/daphne/tests/test_endpoints.py
+++ b/daphne/tests/test_endpoints.py
@@ -1,18 +1,19 @@
 # coding: utf8
 from __future__ import unicode_literals
-from unittest import TestCase
-from six import string_types
-import logging
 
-from ..server import Server, build_endpoint_description_strings
+import logging
+from unittest import TestCase
+
+from six import string_types
+
 from ..cli import CommandLineInterface
+from ..server import Server, build_endpoint_description_strings
 
 # this is the callable that will be tested here
 build = build_endpoint_description_strings
 
 
 class TestEndpointDescriptions(TestCase):
-
     def testBasics(self):
         self.assertEqual(build(), [], msg="Empty list returned when no kwargs given")
 
@@ -46,7 +47,7 @@ class TestEndpointDescriptions(TestCase):
     def testFileDescriptorBinding(self):
         self.assertEqual(
             build(file_descriptor=5),
-            ['fd:domain=INET:fileno=5']
+            ['fd:fileno=5']
         )
 
     def testMultipleEnpoints(self):
@@ -62,13 +63,12 @@ class TestEndpointDescriptions(TestCase):
             sorted([
                 'tcp:port=8080:interface=10.0.0.1',
                 'unix:/tmp/daphne.sock',
-                'fd:domain=INET:fileno=123'
+                'fd:fileno=123'
             ])
         )
 
 
 class TestCLIInterface(TestCase):
-
     # construct a string that will be accepted as the channel_layer argument
     _import_channel_layer_string = 'daphne.tests.asgi:channel_layer'
 
@@ -97,7 +97,8 @@ class TestCLIInterface(TestCase):
         cli = self.build_cli(cli_args=cli_args)
         return cli.server.endpoints
 
-    def checkCLI(self, args='', endpoints=[], msg='Expected endpoints do not match.'):
+    def checkCLI(self, args='', endpoints=None, msg='Expected endpoints do not match.'):
+        endpoints = endpoints or []
         cli = self.build_cli(cli_args=args)
         generated_endpoints = sorted(cli.server.endpoints)
         endpoints.sort()
@@ -149,14 +150,13 @@ class TestCLIInterface(TestCase):
         self.checkCLI(
             '-u /tmp/daphne.sock --fd 5',
             [
-                'fd:domain=INET:fileno=5',
+                'fd:fileno=5',
                 'unix:/tmp/daphne.sock'
             ],
             'File descriptor and unix socket bound, TCP ignored.'
         )
 
     def testMixedCLIEndpointCreation(self):
-
         self.checkCLI(
             '-p 8080 -e unix:/tmp/daphne.sock',
             [


### PR DESCRIPTION
When I start new daphne with file descriptor usage I've got this error.
```
2017-01-23 09:55:36,651 INFO     Starting server at fd:domain=INET:fileno=7, channel layer TPD.asgi:channel_layer.
2017-01-23 09:55:36,662 INFO     Using busy-loop synchronous mode on channel layer
2017-01-23 09:55:36,663 INFO     Listening on endpoint fd:domain=INET:fileno=7
2017-01-23 09:55:36,835 CRITICAL Unhandled error in Deferred:
2017-01-23 09:55:36,838 CRITICAL
Traceback (most recent call last):
  File "/home/jatumba/.virtualenvs/jatumba/lib/python3.5/site-packages/twisted/internet/endpoints.py", line 1019, in listen
    self.fileno, self.addressFamily, factory)
  File "/home/jatumba/.virtualenvs/jatumba/lib/python3.5/site-packages/twisted/internet/posixbase.py", line 442, in adoptStreamPort
    raise error.UnsupportedAddressFamily(addressFamily)
twisted.internet.error.UnsupportedAddressFamily: INET
```
I remove domain=INET and it's all become OK. And I made some small style fix changes. I split this into two different commits.