### PR TITLE
Test against Python 3.4 and multiple Twisted versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 __pycache__
 dist/
 build/
+/.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,16 @@
 sudo: false
+
 language: python
+
 python:
   - "2.7"
+  - "3.4"
   - "3.5"
-install:
-  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then pip install unittest2; fi
-  - pip install asgiref twisted autobahn
-script: if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then python -m unittest2; else python -m unittest; fi
+
+env:
+  - TWISTED_RELEASE="twisted"
+  - TWISTED_RELEASE="twisted==16.0.0"
+
+install: pip install $TWISTED_RELEASE -e .
+
+script: python -m unittest discover

--- a/README.rst
+++ b/README.rst
@@ -67,6 +67,19 @@ should start with a slash, but not end with one; for example::
 
     daphne --root-path=/forum django_project.asgi:channel_layer
 
+Dependencies
+------------
+
+All Channels projects currently support Python 2.7, 3.4 and 3.5. `daphne` requires Twisted 16.0 or
+greater.
+
+Contributing
+------------
+
+Please refer to the
+`main Channels contributing docs <https://github.com/django/channels/blob/master/CONTRIBUTING.rst>`_.
+That also contains advice on how to set up the development environment and run the tests.
+
 
 Maintenance and Security
 ------------------------

--- a/daphne/server.py
+++ b/daphne/server.py
@@ -115,7 +115,7 @@ class Server(object):
         if channels:
             delay = 0.01
             try:
-                channel, message = self.channel_layer.receive_many(channels, block=False)
+                channel, message = self.channel_layer.receive(channels, block=False)
             except Exception as e:
                 logger.error('Error at trying to receive messages: %s' % e)
                 delay = 5.00
@@ -142,7 +142,7 @@ class Server(object):
             channels = self.factory.reply_channels()
             if channels:
                 try:
-                    channel, message = yield self.channel_layer.receive_many_twisted(channels)
+                    channel, message = yield self.channel_layer.receive_twisted(channels)
                 except Exception as e:
                     logger.error('Error at trying to receive messages: %s' % e)
                     yield self.sleep(5.00)

--- a/daphne/tests/test_http.py
+++ b/daphne/tests/test_http.py
@@ -30,7 +30,7 @@ class TestHTTPProtocol(TestCase):
             b"\r\n"
         )
         # Get the resulting message off of the channel layer
-        _, message = self.channel_layer.receive_many(["http.request"])
+        _, message = self.channel_layer.receive(["http.request"])
         self.assertEqual(message['http_version'], "1.1")
         self.assertEqual(message['method'], "GET")
         self.assertEqual(message['scheme'], "http")
@@ -64,7 +64,7 @@ class TestHTTPProtocol(TestCase):
             b"\r\n"
         )
         # Get the resulting message off of the channel layer, check root_path
-        _, message = self.channel_layer.receive_many(["http.request"])
+        _, message = self.channel_layer.receive(["http.request"])
         self.assertEqual(message['root_path'], "/foobar /bar")
 
     def test_http_disconnect_sets_path_key(self):
@@ -78,7 +78,7 @@ class TestHTTPProtocol(TestCase):
             b"\r\n"
         )
         # Get the request message
-        _, message = self.channel_layer.receive_many(["http.request"])
+        _, message = self.channel_layer.receive(["http.request"])
 
         # Send back an example response
         self.factory.dispatch_reply(
@@ -91,7 +91,7 @@ class TestHTTPProtocol(TestCase):
         )
 
         # Get the disconnection notification
-        _, disconnect_message = self.channel_layer.receive_many(["http.disconnect"])
+        _, disconnect_message = self.channel_layer.receive(["http.disconnect"])
         self.assertEqual(disconnect_message['path'], "/te st-à/")
 
     def test_x_forwarded_for_ignored(self):
@@ -106,7 +106,7 @@ class TestHTTPProtocol(TestCase):
             b"\r\n"
         )
         # Get the resulting message off of the channel layer
-        _, message = self.channel_layer.receive_many(["http.request"])
+        _, message = self.channel_layer.receive(["http.request"])
         self.assertEqual(message['client'], ['192.168.1.1', 54321])
 
     def test_x_forwarded_for_parsed(self):
@@ -123,7 +123,7 @@ class TestHTTPProtocol(TestCase):
             b"\r\n"
         )
         # Get the resulting message off of the channel layer
-        _, message = self.channel_layer.receive_many(["http.request"])
+        _, message = self.channel_layer.receive(["http.request"])
         self.assertEqual(message['client'], ['10.1.2.3', 80])
 
     def test_x_forwarded_for_port_missing(self):
@@ -139,5 +139,5 @@ class TestHTTPProtocol(TestCase):
             b"\r\n"
         )
         # Get the resulting message off of the channel layer
-        _, message = self.channel_layer.receive_many(["http.request"])
+        _, message = self.channel_layer.receive(["http.request"])
         self.assertEqual(message['client'], ['10.1.2.3', 0])

--- a/daphne/tests/test_ws.py
+++ b/daphne/tests/test_ws.py
@@ -33,7 +33,7 @@ class TestWebSocketProtocol(TestCase):
             b"\r\n"
         )
         # Get the resulting message off of the channel layer
-        _, message = self.channel_layer.receive_many(["websocket.connect"])
+        _, message = self.channel_layer.receive(["websocket.connect"])
         self.assertEqual(message['path'], "/chat")
         self.assertEqual(message['query_string'], "")
         self.assertEqual(

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     packages=find_packages() + ['twisted.plugins'],
     include_package_data=True,
     install_requires=[
-        'asgiref>=0.13',
+        'asgiref>=1.0.0',
         'twisted>=16.0',
         'autobahn>=0.12',
     ],

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Topic :: Internet :: WWW/HTTP',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+# We test against the oldest supported Twisted release, and the current release.
+[tox]
+envlist = py{27,34,35}-twisted-{old,new}
+
+[testenv]
+deps =
+    twisted-old: twisted==16.0.0
+commands = python -m unittest discover


### PR DESCRIPTION
I agreed with Andrew what versions of Python the channels project should support, and hence am adding 3.4 here. 

I think it makes sense to support a broad range of Twisted
releases, as users of `daphne` are not unlikely to have other Twisted code
running. It's not feasible to test against all releases since 16.0, and
it would require constant maintenance to add new releases as they come
out. So I opted to keep things simple for now, and only test against the
oldest supported and the current Twisted release.

I'm also adding tox to be able to test against those configurations.

This PR builds on the good work of @jpic in https://github.com/django/daphne/pull/19.