### PR TITLE
IPV6 interface binding

### DIFF
--- a/daphne/server.py
+++ b/daphne/server.py
@@ -185,6 +185,7 @@ def build_endpoint_description_strings(
     """
     socket_descriptions = []
     if host and port:
+        host = host.strip('[]').replace(':', '\:')
         socket_descriptions.append('tcp:port=%d:interface=%s' % (int(port), host))
     elif any([host, port]):
         raise ValueError('TCP binding requires both port and host kwargs.')

--- a/daphne/tests/test_endpoints.py
+++ b/daphne/tests/test_endpoints.py
@@ -28,6 +28,16 @@ class TestEndpointDescriptions(TestCase):
             ['tcp:port=8000:interface=127.0.0.1']
         )
 
+        self.assertEqual(
+            build(port=8000, host='[200a::1]'),
+            ['tcp:port=8000:interface=200a\:\:1']
+        )
+
+        self.assertEqual(
+            build(port=8000, host='200a::1'),
+            ['tcp:port=8000:interface=200a\:\:1']
+        )
+
         # incomplete port/host kwargs raise errors
         self.assertRaises(
             ValueError,
@@ -122,6 +132,14 @@ class TestCLIInterface(TestCase):
         self.checkCLI(
             '-b 10.0.0.1',
             ['tcp:port=8000:interface=10.0.0.1']
+        )
+        self.checkCLI(
+            '-b 200a::1',
+            ['tcp:port=8000:interface=200a\:\:1']
+        )
+        self.checkCLI(
+            '-b [200a::1]',
+            ['tcp:port=8000:interface=200a\:\:1']
         )
         self.checkCLI(
             '-p 8080 -b example.com',


### PR DESCRIPTION
I've been using django channels and found that it's not possible to use IPv6 address for the binding interface:

```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/django/utils/autoreload.py", line 226, in wrapper
    fn(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/channels/management/commands/runserver.py", line 89, in inner_run
    root_path=getattr(settings, 'FORCE_SCRIPT_NAME', '') or '',
  File "/usr/local/lib/python2.7/site-packages/daphne/server.py", line 98, in run
    ep = serverFromString(reactor, str(socket_description))
  File "/usr/local/lib/python2.7/site-packages/twisted/internet/endpoints.py", line 1522, in serverFromString
    return _serverFromStringLegacy(reactor, description, _NO_DEFAULT)
  File "/usr/local/lib/python2.7/site-packages/twisted/internet/endpoints.py", line 1435, in _serverFromStringLegacy
    nameOrPlugin, args, kw = _parseServer(description, None, default)
  File "/usr/local/lib/python2.7/site-packages/twisted/internet/endpoints.py", line 1426, in _parseServer
    return (endpointType.upper(),) + parser(factory, *args[1:], **kw)
TypeError: _parseTCP() got multiple values for keyword argument 'interface'
```

I've investigated the problem and found that `serverFromString` expects a string in the format like `tcp:port=80:interface=192.168.1.1`. But when you use `python manage.py runserver [::]:8000` you get string like `tcp:port=80:interface=::`. As I understand the `:` is the delimiter and should be escaped `tcp:port=80:interface=\:\:`