### PR TITLE
Run tox tests from travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,8 @@ python:
   - "2.7"
   - "3.4"
   - "3.5"
+  - "3.6"
 
-env:
-  - TWISTED_RELEASE="twisted"
-  - TWISTED_RELEASE="twisted==17.1.0"
+install: pip install tox tox-travis
 
-install: pip install $TWISTED_RELEASE -e .[tests]
-
-script: python -m unittest discover
+script: tox

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Internet :: WWW/HTTP',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 # We test against the oldest supported Twisted release, and the current release.
 [tox]
-envlist = py{27,34,35}-twisted-{old,new}
+envlist = py{27,34,35,36}-twisted-{old,new}
 
 [testenv]
-extras = tests
 deps =
     twisted-old: twisted==17.1.0
-commands = python -m unittest discover
+commands =
+    pip install -e .[tests]
+    python -m unittest discover


### PR DESCRIPTION
It run the tests on Python 3.6 too.

PS: the twisted-old tests could also (and probably should) be achieved using Requirements-Builder.