### PR TITLE
Websockets test and unicode fix for Python 2

### DIFF
--- a/daphne/tests/factories.py
+++ b/daphne/tests/factories.py
@@ -84,6 +84,19 @@ def _build_request(method, path, params=None, headers=None, body=None):
     return request
 
 
+def build_websocket_upgrade(path, params, headers):
+    ws_headers = [
+        ('Host', 'somewhere.com'),
+        ('Upgrade', 'websocket'),
+        ('Connection', 'Upgrade'),
+        ('Sec-WebSocket-Key', 'x3JJHMbDL1EzLkh9GBhXDw=='),
+        ('Sec-WebSocket-Protocol', 'chat, superchat'),
+        ('Sec-WebSocket-Version', '13'),
+        ('Origin', 'http://example.com')
+    ]
+    return _build_request('GET', path, params, headers=headers + ws_headers, body=None)
+
+
 def header_line(name, value):
     """
     Given a header name and value, returns the line to use in a HTTP request or response.

--- a/daphne/tests/http_strategies.py
+++ b/daphne/tests/http_strategies.py
@@ -17,12 +17,17 @@ def http_method():
     return strategies.sampled_from(HTTP_METHODS)
 
 
+def _http_path_portion():
+    alphabet = string.ascii_letters + string.digits + '-._~'
+    return strategies.text(min_size=1, average_size=10, max_size=128, alphabet=alphabet)
+
+
 def http_path():
     """
     Returns a URL path (not encoded).
     """
-    alphabet = string.ascii_letters + string.digits + '-._~/'
-    return strategies.text(min_size=0, max_size=255, alphabet=alphabet).map(lambda s: '/' + s)
+    return strategies.lists(
+        _http_path_portion(), min_size=0, max_size=10).map(lambda s: '/' + '/'.join(s))
 
 
 def http_body():
@@ -31,6 +36,10 @@ def http_body():
     but seems to not cause an issue so far.
     """
     return strategies.text(alphabet=string.printable, min_size=0, average_size=600, max_size=1500)
+
+
+def binary_payload():
+    return strategies.binary(min_size=0, average_size=600, max_size=1500)
 
 
 def valid_bidi(value):

--- a/daphne/tests/test_http_request.py
+++ b/daphne/tests/test_http_request.py
@@ -16,7 +16,7 @@ from daphne.tests import testcases, http_strategies
 from daphne.tests.factories import message_for_request, content_length_header
 
 
-class TestHTTPRequestSpec(testcases.ASGITestCase):
+class TestHTTPRequestSpec(testcases.ASGIHTTPTestCase):
     """
     Tests which try to pour the HTTP request section of the ASGI spec into code.
     The heavy lifting is done by the assert_valid_http_request_message function,

--- a/daphne/tests/test_http_response.py
+++ b/daphne/tests/test_http_response.py
@@ -14,7 +14,7 @@ from daphne.http_protocol import HTTPFactory
 from . import factories, http_strategies, testcases
 
 
-class TestHTTPResponseSpec(testcases.ASGITestCase):
+class TestHTTPResponseSpec(testcases.ASGIHTTPTestCase):
 
     def test_minimal_response(self):
         """

--- a/daphne/tests/test_ws.py
+++ b/daphne/tests/test_ws.py
@@ -1,27 +1,171 @@
 # coding: utf8
 from __future__ import unicode_literals
-from unittest import TestCase
-from asgiref.inmemory import ChannelLayer
+
+from hypothesis import assume, given, strategies
 from twisted.test import proto_helpers
 
+from asgiref.inmemory import ChannelLayer
 from daphne.http_protocol import HTTPFactory
+from daphne.tests import http_strategies, testcases, factories
 
 
-class TestWebSocketProtocol(TestCase):
+class WebSocketConnection(object):
     """
-    Tests that the WebSocket protocol class correcly generates and parses messages.
+    Helper class that makes it easier to test Dahpne's WebSocket support.
     """
 
-    def setUp(self):
+    def __init__(self):
+        self.last_message = None
+
         self.channel_layer = ChannelLayer()
         self.factory = HTTPFactory(self.channel_layer, send_channel="test!")
         self.proto = self.factory.buildProtocol(('127.0.0.1', 0))
-        self.tr = proto_helpers.StringTransport()
-        self.proto.makeConnection(self.tr)
+        self.transport = proto_helpers.StringTransport()
+        self.proto.makeConnection(self.transport)
+
+    def receive(self, request):
+        """
+        Low-level method to let Daphne handle HTTP/WebSocket data
+        """
+        self.proto.dataReceived(request)
+        _, self.last_message = self.channel_layer.receive(['websocket.connect'])
+        return self.last_message
+
+    def send(self, content):
+        """
+        Method to respond with a channel message
+        """
+        if self.last_message is None:
+            # Auto-connect for convenience.
+            self.connect()
+        self.factory.dispatch_reply(self.last_message['reply_channel'], content)
+        response = self.transport.value()
+        self.transport.clear()
+        return response
+
+    def connect(self, path='/', params=None, headers=None):
+        """
+        High-level method to perform the WebSocket handshake
+        """
+        request = factories.build_websocket_upgrade(path, params, headers or [])
+        message = self.receive(request)
+        return message
+
+
+class TestHandshake(testcases.ASGIWebSocketTestCase):
+    """
+    Tests for the WebSocket handshake
+    """
+
+    def test_minimal(self):
+        message = WebSocketConnection().connect()
+        self.assert_valid_websocket_connect_message(message)
+
+    @given(
+        path=http_strategies.http_path(),
+        params=http_strategies.query_params(),
+        headers=http_strategies.headers(),
+    )
+    def test_connection(self, path, params, headers):
+        message = WebSocketConnection().connect(path, params, headers)
+        self.assert_valid_websocket_connect_message(message, path, params, headers)
+
+
+class TestSendCloseAccept(testcases.ASGIWebSocketTestCase):
+    """
+    Tests that, essentially, try to translate the send/close/accept section of the spec into code.
+    """
+
+    def test_empty_accept(self):
+        response = WebSocketConnection().send({'accept': True})
+        self.assert_websocket_upgrade(response)
+
+    @given(text=http_strategies.http_body())
+    def test_accept_and_text(self, text):
+        response = WebSocketConnection().send({'accept': True, 'text': text})
+        self.assert_websocket_upgrade(response, text.encode('ascii'))
+
+    @given(data=http_strategies.binary_payload())
+    def test_accept_and_bytes(self, data):
+        response = WebSocketConnection().send({'accept': True, 'bytes': data})
+        self.assert_websocket_upgrade(response, data)
+
+    def test_accept_false(self):
+        response = WebSocketConnection().send({'accept': False})
+        self.assert_websocket_denied(response)
+
+    def test_accept_false_with_text(self):
+        """
+        Tests that even if text is given, the connection is denied.
+
+        We can't easily use Hypothesis to generate data for this test because it's
+        hard to detect absence of the body if e.g. Hypothesis would generate a 'GET'
+        """
+        text = 'foobar'
+        response = WebSocketConnection().send({'accept': False, 'text': text})
+        self.assert_websocket_denied(response)
+        self.assertNotIn(text.encode('ascii'), response)
+
+    def test_accept_false_with_bytes(self):
+        """
+        Tests that even if data is given, the connection is denied.
+
+        We can't easily use Hypothesis to generate data for this test because it's
+        hard to detect absence of the body if e.g. Hypothesis would generate a 'GET'
+        """
+        data = b'foobar'
+        response = WebSocketConnection().send({'accept': False, 'bytes': data})
+        self.assert_websocket_denied(response)
+        self.assertNotIn(data, response)
+
+    @given(text=http_strategies.http_body())
+    def test_just_text(self, text):
+        assume(len(text) > 0)
+        # If content is sent, accept=True is implied.
+        response = WebSocketConnection().send({'text': text})
+        self.assert_websocket_upgrade(response, text.encode('ascii'))
+
+    @given(data=http_strategies.binary_payload())
+    def test_just_bytes(self, data):
+        assume(len(data) > 0)
+        # If content is sent, accept=True is implied.
+        response = WebSocketConnection().send({'bytes': data})
+        self.assert_websocket_upgrade(response, data)
+
+    def test_close_boolean(self):
+        response = WebSocketConnection().send({'close': True})
+        self.assert_websocket_denied(response)
+
+    @given(number=strategies.integers(min_value=1))
+    def test_close_integer(self, number):
+        response = WebSocketConnection().send({'close': number})
+        self.assert_websocket_denied(response)
+
+    @given(text=http_strategies.http_body())
+    def test_close_with_text(self, text):
+        assume(len(text) > 0)
+        response = WebSocketConnection().send({'close': True, 'text': text})
+        self.assert_websocket_upgrade(response, text.encode('ascii'), expect_close=True)
+
+    @given(data=http_strategies.binary_payload())
+    def test_close_with_data(self, data):
+        assume(len(data) > 0)
+        response = WebSocketConnection().send({'close': True, 'bytes': data})
+        self.assert_websocket_upgrade(response, data, expect_close=True)
+
+
+class TestWebSocketProtocol(testcases.ASGIWebSocketTestCase):
+    """
+    Tests that the WebSocket protocol class correctly generates and parses messages.
+    """
+
+    def setUp(self):
+        self.connection = WebSocketConnection()
 
     def test_basic(self):
-        # Send a simple request to the protocol
-        self.proto.dataReceived(
+        # Send a simple request to the protocol and get the resulting message off
+        # of the channel layer.
+        message = self.connection.receive(
             b"GET /chat HTTP/1.1\r\n"
             b"Host: somewhere.com\r\n"
             b"Upgrade: websocket\r\n"
@@ -32,8 +176,6 @@ class TestWebSocketProtocol(TestCase):
             b"Origin: http://example.com\r\n"
             b"\r\n"
         )
-        # Get the resulting message off of the channel layer
-        _, message = self.channel_layer.receive(["websocket.connect"])
         self.assertEqual(message['path'], "/chat")
         self.assertEqual(message['query_string'], "")
         self.assertEqual(
@@ -46,53 +188,26 @@ class TestWebSocketProtocol(TestCase):
              (b'sec-websocket-version', b'13'),
              (b'upgrade', b'websocket')]
         )
-        self.assertTrue(message['reply_channel'].startswith("test!"))
+        self.assert_valid_websocket_connect_message(message, '/chat')
 
         # Accept the connection
-        self.factory.dispatch_reply(
-            message['reply_channel'],
-            {'accept': True}
-        )
-
-        # Make sure that we get a 101 Switching Protocols back
-        response = self.tr.value()
-        self.assertIn(b"HTTP/1.1 101 Switching Protocols\r\n", response)
-        self.assertIn(b"Sec-WebSocket-Accept: HSmrc0sMlYUkAGmm5OPpG2HaGWk=\r\n", response)
-        self.tr.clear()
+        response = self.connection.send({'accept': True})
+        self.assert_websocket_upgrade(response)
 
         # Send some text
-        self.factory.dispatch_reply(
-            message['reply_channel'],
-            {'text': "Hello World!"}
-        )
-
-        response = self.tr.value()
+        response = self.connection.send({'text': "Hello World!"})
         self.assertEqual(response, b"\x81\x0cHello World!")
-        self.tr.clear()
 
         # Send some bytes
-        self.factory.dispatch_reply(
-            message['reply_channel'],
-            {'bytes': b"\xaa\xbb\xcc\xdd"}
-        )
-
-        response = self.tr.value()
+        response = self.connection.send({'bytes': b"\xaa\xbb\xcc\xdd"})
         self.assertEqual(response, b"\x82\x04\xaa\xbb\xcc\xdd")
-        self.tr.clear()
 
         # Close the connection
-        self.factory.dispatch_reply(
-            message['reply_channel'],
-            {'close': True}
-        )
-
-        response = self.tr.value()
+        response = self.connection.send({'close': True})
         self.assertEqual(response, b"\x88\x02\x03\xe8")
-        self.tr.clear()
 
     def test_connection_with_file_origin_is_accepted(self):
-        # Send a simple request to the protocol
-        self.proto.dataReceived(
+        message = self.connection.receive(
             b"GET /chat HTTP/1.1\r\n"
             b"Host: somewhere.com\r\n"
             b"Upgrade: websocket\r\n"
@@ -103,26 +218,15 @@ class TestWebSocketProtocol(TestCase):
             b"Origin: file://\r\n"
             b"\r\n"
         )
-
-        # Get the resulting message off of the channel layer
-        _, message = self.channel_layer.receive(["websocket.connect"])
         self.assertIn((b'origin', b'file://'), message['headers'])
-        self.assertTrue(message['reply_channel'].startswith("test!"))
+        self.assert_valid_websocket_connect_message(message, '/chat')
 
         # Accept the connection
-        self.factory.dispatch_reply(
-            message['reply_channel'],
-            {'accept': True}
-        )
-
-        # Make sure that we get a 101 Switching Protocols back
-        response = self.tr.value()
-        self.assertIn(b"HTTP/1.1 101 Switching Protocols\r\n", response)
-        self.assertIn(b"Sec-WebSocket-Accept: HSmrc0sMlYUkAGmm5OPpG2HaGWk=\r\n", response)
+        response = self.connection.send({'accept': True})
+        self.assert_websocket_upgrade(response)
 
     def test_connection_with_no_origin_is_accepted(self):
-        # Send a simple request to the protocol
-        self.proto.dataReceived(
+        message = self.connection.receive(
             b"GET /chat HTTP/1.1\r\n"
             b"Host: somewhere.com\r\n"
             b"Upgrade: websocket\r\n"
@@ -133,18 +237,9 @@ class TestWebSocketProtocol(TestCase):
             b"\r\n"
         )
 
-        # Get the resulting message off of the channel layer
-        _, message = self.channel_layer.receive(["websocket.connect"])
         self.assertNotIn(b'origin', [header_tuple[0] for header_tuple in message['headers']])
-        self.assertTrue(message['reply_channel'].startswith("test!"))
+        self.assert_valid_websocket_connect_message(message, '/chat')
 
         # Accept the connection
-        self.factory.dispatch_reply(
-            message['reply_channel'],
-            {'accept': True}
-        )
-
-        # Make sure that we get a 101 Switching Protocols back
-        response = self.tr.value()
-        self.assertIn(b"HTTP/1.1 101 Switching Protocols\r\n", response)
-        self.assertIn(b"Sec-WebSocket-Accept: HSmrc0sMlYUkAGmm5OPpG2HaGWk=\r\n", response)
+        response = self.connection.send({'accept': True})
+        self.assert_websocket_upgrade(response)

--- a/daphne/ws_protocol.py
+++ b/daphne/ws_protocol.py
@@ -50,9 +50,11 @@ class WebSocketProtocol(WebSocketServerProtocol):
             # Tell main factory about it
             self.main_factory.reply_protocols[self.reply_channel] = self
             # Get client address if possible
-            if hasattr(self.transport.getPeer(), "host") and hasattr(self.transport.getPeer(), "port"):
-                self.client_addr = [self.transport.getPeer().host, self.transport.getPeer().port]
-                self.server_addr = [self.transport.getHost().host, self.transport.getHost().port]
+            peer = self.transport.getPeer()
+            host = self.transport.getHost()
+            if hasattr(peer, "host") and hasattr(peer, "port"):
+                self.client_addr = [six.text_type(peer.host), peer.port]
+                self.server_addr = [six.text_type(host.host), host.port]
             else:
                 self.client_addr = None
                 self.server_addr = None


### PR DESCRIPTION
Similarly to my previous work, I'm adding a new test class to help write tests, refactored some of the existing ones, and added a couple new ones. I also fixed a Python 2 byte string issue that also appeared in the HTTP protocol.

This PR currently has one failing test for Python 2, which rather likely is highlighting https://github.com/django/daphne/issues/108, as it fails for unicode query params. I suggest merging this PR, as it eases reproducing the issue. 