### PR TITLE
Set HTTP Server header to "Daphne" for security's sake

### DIFF
--- a/daphne/http_protocol.py
+++ b/daphne/http_protocol.py
@@ -323,7 +323,7 @@ class HTTPFactory(http.HTTPFactory):
         # We track all sub-protocols for response channel mapping
         self.reply_protocols = {}
         # Make a factory for WebSocket protocols
-        self.ws_factory = WebSocketFactory(self, protocols=ws_protocols)
+        self.ws_factory = WebSocketFactory(self, protocols=ws_protocols, server='Daphne')
         self.ws_factory.setProtocolOptions(
             autoPingTimeout=ping_timeout,
             allowNullOrigin=True,


### PR DESCRIPTION
By default, AutobahnPython HTTP responses include a Server: header which includes its version number -- for example, "Server: AutobahnPython/0.17.1"

While not a bug, and obscurity is not security, in most production setups it is still preferable to not reveal minor version numbers.

This patch sets the HTTP Server: header to "Daphne" without a version number.