### PR TITLE
Parse X-Forwarded-Proto header

### DIFF
--- a/daphne/cli.py
+++ b/daphne/cli.py
@@ -213,6 +213,7 @@ class CommandLineInterface(object):
             verbosity=args.verbosity,
             proxy_forwarded_address_header='X-Forwarded-For' if args.proxy_headers else None,
             proxy_forwarded_port_header='X-Forwarded-Port' if args.proxy_headers else None,
+            proxy_forwarded_proto_header='X-Forwarded-Proto' if args.proxy_headers else None,
             force_sync=args.force_sync,
         )
         self.server.run()

--- a/daphne/http_protocol.py
+++ b/daphne/http_protocol.py
@@ -80,12 +80,16 @@ class WebRequest(http.Request):
                 self.client_addr = None
                 self.server_addr = None
 
+            self.client_scheme = 'https' if self.isSecure() else 'http'
+
             if self.factory.proxy_forwarded_address_header:
-                self.client_addr = parse_x_forwarded_for(
+                self.client_addr, self.client_scheme = parse_x_forwarded_for(
                     self.requestHeaders,
                     self.factory.proxy_forwarded_address_header,
                     self.factory.proxy_forwarded_port_header,
-                    self.client_addr
+                    self.factory.proxy_forwarded_proto_header,
+                    self.client_addr,
+                    self.client_scheme
                 )
 
             # Check for unicodeish path (or it'll crash when trying to parse)
@@ -166,7 +170,7 @@ class WebRequest(http.Request):
                         "method": self.method.decode("ascii"),
                         "path": self.unquote(self.path),
                         "root_path": self.root_path,
-                        "scheme": "https" if self.isSecure() else "http",
+                        "scheme": self.client_scheme,
                         "query_string": self.query_string,
                         "headers": self.clean_headers,
                         "body": self.content.read(),

--- a/daphne/server.py
+++ b/daphne/server.py
@@ -36,6 +36,7 @@ class Server(object):
         root_path="",
         proxy_forwarded_address_header=None,
         proxy_forwarded_port_header=None,
+        proxy_forwarded_proto_header=None,
         force_sync=False,
         verbosity=1,
         websocket_handshake_timeout=5
@@ -66,6 +67,7 @@ class Server(object):
         self.ping_timeout = ping_timeout
         self.proxy_forwarded_address_header = proxy_forwarded_address_header
         self.proxy_forwarded_port_header = proxy_forwarded_port_header
+        self.proxy_forwarded_proto_header = proxy_forwarded_proto_header
         # If they did not provide a websocket timeout, default it to the
         # channel layer's group_expiry value if present, or one day if not.
         self.websocket_timeout = websocket_timeout or getattr(channel_layer, "group_expiry", 86400)
@@ -95,6 +97,7 @@ class Server(object):
             root_path=self.root_path,
             proxy_forwarded_address_header=self.proxy_forwarded_address_header,
             proxy_forwarded_port_header=self.proxy_forwarded_port_header,
+            proxy_forwarded_proto_header=self.proxy_forwarded_proto_header,
             websocket_handshake_timeout=self.websocket_handshake_timeout
         )
         if self.verbosity <= 1:

--- a/daphne/tests/test_http_request.py
+++ b/daphne/tests/test_http_request.py
@@ -171,6 +171,7 @@ class TestProxyHandling(unittest.TestCase):
     def test_x_forwarded_for_parsed(self):
         self.factory.proxy_forwarded_address_header = 'X-Forwarded-For'
         self.factory.proxy_forwarded_port_header = 'X-Forwarded-Port'
+        self.factory.proxy_forwarded_proto_header = 'X-Forwarded-Proto'
         self.proto.dataReceived(
             b"GET /te%20st-%C3%A0/?foo=+bar HTTP/1.1\r\n" +
             b"Host: somewhere.com\r\n" +
@@ -185,6 +186,7 @@ class TestProxyHandling(unittest.TestCase):
     def test_x_forwarded_for_port_missing(self):
         self.factory.proxy_forwarded_address_header = 'X-Forwarded-For'
         self.factory.proxy_forwarded_port_header = 'X-Forwarded-Port'
+        self.factory.proxy_forwarded_proto_header = 'X-Forwarded-Proto'
         self.proto.dataReceived(
             b"GET /te%20st-%C3%A0/?foo=+bar HTTP/1.1\r\n" +
             b"Host: somewhere.com\r\n" +

--- a/daphne/utils.py
+++ b/daphne/utils.py
@@ -22,7 +22,7 @@ def parse_x_forwarded_for(headers,
     @param port_header_name: The name of the expected port header
     @param proto_header_name: The name of the expected protocol header
     @param original_addr: A host/port pair that should be returned if the headers are not in the request
-    @param original_scheme: A scheme hat should be returned if the headers are not in the request
+    @param original_scheme: A scheme that should be returned if the headers are not in the request
     @return: A tuple containing a list [host (string), port (int)] as the first entry and a proto (string) as the second
     """
     if not address_header_name:

--- a/daphne/ws_protocol.py
+++ b/daphne/ws_protocol.py
@@ -57,10 +57,11 @@ class WebSocketProtocol(WebSocketServerProtocol):
                 self.server_addr = None
 
             if self.main_factory.proxy_forwarded_address_header:
-                self.client_addr = parse_x_forwarded_for(
+                self.client_addr, = parse_x_forwarded_for(
                     self.http_headers,
                     self.main_factory.proxy_forwarded_address_header,
                     self.main_factory.proxy_forwarded_port_header,
+                    self.main_factory.proxy_forwarded_proto_header,
                     self.client_addr
                 )
 


### PR DESCRIPTION
Reworked it somewhat from https://github.com/django/daphne/pull/135, in my own fork (thanks for intial work @tiltec!).

I have:
* added tests
* make the header name configurable, as with other similar headers
* reworked the style a bit - to avoid calling `self.setHost()` [1]

How does it look?

[1] it looks like perhaps it _should_ be setting setHost, as per [twisted docs](https://github.com/racker/python-twisted-web/blob/master/twisted/web/http.py#L1129-L1140) but I removed it as it wasn't already setting it