### PR TITLE
Update Readme.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ Daphne 1.1 and above supports terminating HTTP/2 connections natively. You'll
 need to do a couple of things to get it working, though. First, you need to
 make sure you install the Twisted ``http2`` and ``tls`` extras::
 
-    pip install -U Twisted[tls,http2]
+    pip install -U 'Twisted[tls,http2]'
 
 Next, because all current browsers only support HTTP/2 when using TLS, you will
 need to start Daphne with TLS turned on, which can be done using the Twisted endpoint syntax::


### PR DESCRIPTION
When you use  `pip install -U Twisted[tls,http2]` you get an error because the syntax is not correct for pip.`
 
The correct syntax is `pip install -U 'Twisted[tls,http2]'`