### PR TITLE
Bug issue with upgrading http to websocket

### DIFF
--- a/daphne/http_protocol.py
+++ b/daphne/http_protocol.py
@@ -117,6 +117,9 @@ class WebRequest(http.Request):
                 data += self.content.read()
                 protocol.dataReceived(data)
                 # Remove our HTTP reply channel association
+                # FIXME: Something wrong is happening here.
+                # http protocol won't remove after upgrade to protocol websocket,
+                # which results to http timeout and disconnect websocket.
                 logger.debug("Upgraded connection %s to WebSocket", self.client_addr)
                 # Resume the producer so we keep getting data, if it's available as a method
                 self.channel._networkProducer.resumeProducing()


### PR DESCRIPTION
The following output is from daphne protocol server when running the ./manage.py runserver with full verbosity:

- Creating a websocket connection
`
2018-02-04 13:01:58,975 - DEBUG - http_protocol - Upgraded connection ['127.0.0.1', 39558] to WebSocket
2018-02-04 13:01:59,010 - DEBUG - ws_protocol - WebSocket ['127.0.0.1', 39558] open and established
[2018/02/04 13:01:59] WebSocket CONNECT /test/ [127.0.0.1:39558]
2018-02-04 13:01:59,010 - DEBUG - ws_protocol - WebSocket ['127.0.0.1', 39558] accepted by application
`
- ...after 60 seconds (the default value of --http_timeout)
`
2018-02-04 13:02:59,944 - DEBUG - http_protocol - HTTP 503 response started for ['127.0.0.1', 39558]
2018-02-04 13:02:59,945 - DEBUG - http_protocol - HTTP close for ['127.0.0.1', 39558]
2018-02-04 13:02:59,945 - DEBUG - http_protocol - HTTP response complete for ['127.0.0.1', 39558]
[2018/02/04 13:02:59] HTTP GET /test/ 503 [60.97, 127.0.0.1:39558]
2018-02-04 13:02:59,950 - DEBUG - ws_protocol - WebSocket closed for ['127.0.0.1', 39558]
[2018/02/04 13:02:59] WebSocket DISCONNECT /test/ [127.0.0.1:39558]
`