### PR TITLE
removed deferToThread for ASGI instance constructor

### DIFF
--- a/daphne/http_protocol.py
+++ b/daphne/http_protocol.py
@@ -3,7 +3,7 @@ import time
 import traceback
 from urllib.parse import unquote
 
-from twisted.internet.defer import inlineCallbacks
+from twisted.internet.defer import inlineCallbacks, maybeDeferred
 from twisted.internet.interfaces import IProtocolNegotiationFactory
 from twisted.protocols.policies import ProtocolWrapper
 from twisted.web import http
@@ -146,7 +146,7 @@ class WebRequest(http.Request):
                 logger.debug("HTTP %s request for %s", self.method, self.client_addr)
                 self.content.seek(0, 0)
                 # Work out the application scope and create application
-                self.application_queue = yield self.server.create_application(self, {
+                self.application_queue = yield maybeDeferred(self.server.create_application, self, {
                     "type": "http",
                     # TODO: Correctly say if it's 1.1 or 1.0
                     "http_version": self.clientproto.split(b"/")[-1].decode("ascii"),

--- a/daphne/server.py
+++ b/daphne/server.py
@@ -183,7 +183,7 @@ class Server(object):
         assert "application_instance" not in self.connections[protocol]
         # Make an instance of the application
         input_queue = asyncio.Queue()
-        application_instance = yield deferToThread(self.application, scope=scope)
+        application_instance = self.application(scope=scope)
         # Run it, and stash the future for later checking
         if protocol not in self.connections:
             return None

--- a/daphne/server.py
+++ b/daphne/server.py
@@ -24,7 +24,6 @@ from concurrent.futures import CancelledError
 
 from twisted.internet import defer, reactor
 from twisted.internet.endpoints import serverFromString
-from twisted.internet.threads import deferToThread
 from twisted.logger import STDLibLogObserver, globalLogBeginner
 from twisted.web import http
 
@@ -171,7 +170,6 @@ class Server(object):
 
     ### Internal event/message handling
 
-    @defer.inlineCallbacks
     def create_application(self, protocol, scope):
         """
         Creates a new application instance that fronts a Protocol instance

--- a/daphne/ws_protocol.py
+++ b/daphne/ws_protocol.py
@@ -66,7 +66,7 @@ class WebSocketProtocol(WebSocketServerProtocol):
                     ]
             # Make new application instance with scope
             self.path = request.path.encode("ascii")
-            self.application_deferred = self.server.create_application(self, {
+            self.application_deferred = defer.maybeDeferred(self.server.create_application, self, {
                 "type": "websocket",
                 "path": unquote(self.path.decode("ascii")),
                 "headers": self.clean_headers,


### PR DESCRIPTION
As it is not needed anymore (per #188 comment) it should be removed to remove confusion and because it should be unnecessary.