### PR TITLE
Configurable servername

### DIFF
--- a/daphne/cli.py
+++ b/daphne/cli.py
@@ -150,6 +150,13 @@ class CommandLineInterface(object):
             "application",
             help="The application to dispatch to as path.to.module:instance.path",
         )
+        self.parser.add_argument(
+            "-s",
+            "--server-name",
+            dest="server_name",
+            help="specify which value should be passed to response header Server attribute",
+            default="Daphne",
+        )
 
         self.server = None
 
@@ -267,5 +274,6 @@ class CommandLineInterface(object):
             proxy_forwarded_proto_header="X-Forwarded-Proto"
             if args.proxy_headers
             else None,
+            server_name=args.server_name,
         )
         self.server.run()

--- a/daphne/http_protocol.py
+++ b/daphne/http_protocol.py
@@ -239,6 +239,8 @@ class WebRequest(http.Request):
             # Write headers
             for header, value in message.get("headers", {}):
                 self.responseHeaders.addRawHeader(header, value)
+            if self.server.server_name and self.server.server_name.lower() != "daphne":
+                self.setHeader(b"server", self.server.server_name.encode("utf-8"))
             logger.debug(
                 "HTTP %s response started for %s", message["status"], self.client_addr
             )

--- a/daphne/server.py
+++ b/daphne/server.py
@@ -54,6 +54,7 @@ class Server(object):
         websocket_handshake_timeout=5,
         application_close_timeout=10,
         ready_callable=None,
+        server_name="Daphne",
         # Deprecated and does not work, remove in version 2.2
         ws_protocols=None,
     ):
@@ -77,6 +78,7 @@ class Server(object):
         self.verbosity = verbosity
         self.abort_start = False
         self.ready_callable = ready_callable
+        self.server_name = server_name
         # Check our construction is actually sensible
         if not self.endpoints:
             logger.error("No endpoints. This server will not listen on anything.")
@@ -87,7 +89,7 @@ class Server(object):
         self.connections = {}
         # Make the factory
         self.http_factory = HTTPFactory(self)
-        self.ws_factory = WebSocketFactory(self, server="Daphne")
+        self.ws_factory = WebSocketFactory(self, server=self.server_name)
         self.ws_factory.setProtocolOptions(
             autoPingTimeout=self.ping_timeout,
             allowNullOrigin=True,


### PR DESCRIPTION
I just want the response header attribute `Server` to display something else like `Apache` instead of `Daphne`. So I made these commits to allow an user to pass their own servername as cli argument.