### PR TITLE
Resolve asyncio + multiprocessing problem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 *.egg-info
 *.pyc
 __pycache__

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,43 @@ jobs:
       dist: xenial
       sudo: required
 
+    - os: osx
+      language: generic
+      python: '3.5'
+      env: TWISTED="twisted==18.7.0"
+      before_install:
+        - eval "$(pyenv init -)"
+        - pyenv install 3.5.5
+        - pyenv global 3.5.5
+      sudo: required
+    - os: osx
+      language: generic
+      python: '3.5'
+      env: TWISTED="twisted"
+      before_install:
+        - eval "$(pyenv init -)"
+        - pyenv install 3.5.5
+        - pyenv global 3.5.5
+      sudo: required
+    - os: osx
+      language: generic
+      python: '3.6'
+      env: TWISTED="twisted==18.7.0"
+      before_install:
+        - eval "$(pyenv init -)"
+        - pyenv install 3.6.5
+        - pyenv global 3.6.5
+      sudo: required
+    - os: osx
+      language: generic
+      python: '3.6'
+      env: TWISTED="twisted"
+      before_install:
+        - eval "$(pyenv init -)"
+        - pyenv install 3.6.5
+        - pyenv global 3.6.5
+      sudo: required
+
     - stage: lint
       install: pip install -U -e .[tests] black pyflakes isort
       script:

--- a/daphne/testing.py
+++ b/daphne/testing.py
@@ -126,9 +126,11 @@ class DaphneProcess(multiprocessing.Process):
             # This is necessary because asyncio behaves badly with multiprocessing.
             from twisted.internet import asyncioreactor
             import sys
+
             current_reactor = sys.modules.get("twisted.internet.reactor")
             if isinstance(current_reactor, asyncioreactor.AsyncioSelectorReactor):
                 import asyncio
+
                 current_reactor._asyncioEventloop.close()
                 asyncio.set_event_loop(asyncio.new_event_loop())
                 current_reactor._asyncioEventloop = asyncio.get_event_loop()

--- a/daphne/testing.py
+++ b/daphne/testing.py
@@ -6,11 +6,6 @@ import tempfile
 import traceback
 from concurrent.futures import CancelledError
 
-from twisted.internet import reactor
-
-from .endpoints import build_endpoint_description_strings
-from .server import Server
-
 
 class DaphneTestingInstance:
     """
@@ -121,19 +116,18 @@ class DaphneProcess(multiprocessing.Process):
         self.errors = multiprocessing.Queue()
 
     def run(self):
+        # OK, now we are in a forked child process, and want to use the reactor.
+        # However, FreeBSD systems like MacOS do not fork the underlying Kqueue,
+        # which asyncio (hence asyncioreactor) is built on.
+        # Therefore, we should uninstall the broken reactor and install a new one.
+        _reinstall_reactor()
+
+        from twisted.internet import reactor
+
+        from .server import Server
+        from .endpoints import build_endpoint_description_strings
+
         try:
-            # Renew the asyncio event loop without anyone knowing.
-            # This is necessary because asyncio behaves badly with multiprocessing.
-            from twisted.internet import asyncioreactor
-            import sys
-
-            current_reactor = sys.modules.get("twisted.internet.reactor")
-            if isinstance(current_reactor, asyncioreactor.AsyncioSelectorReactor):
-                import asyncio
-
-                current_reactor._asyncioEventloop.close()
-                asyncio.set_event_loop(asyncio.new_event_loop())
-                current_reactor._asyncioEventloop = asyncio.get_event_loop()
             # Create the server class
             endpoints = build_endpoint_description_strings(host=self.host, port=0)
             self.server = Server(
@@ -155,6 +149,8 @@ class DaphneProcess(multiprocessing.Process):
             self.errors.put((e, traceback.format_exc()))
 
     def resolve_port(self):
+        from twisted.internet import reactor
+
         if self.server.listening_addresses:
             self.port.value = self.server.listening_addresses[0][1]
             self.ready.set()
@@ -261,3 +257,24 @@ class TestApplication:
             os.unlink(cls.result_storage)
         except OSError:
             pass
+
+
+def _reinstall_reactor():
+    import sys
+    import asyncio
+
+    from twisted.internet import asyncioreactor
+
+    # Uninstall the reactor.
+    if "twisted.internet.reactor" in sys.modules:
+        del sys.modules["twisted.internet.reactor"]
+
+    # The daphne.server module may have already installed the reactor.
+    # If so, using this module will use uninstalled one, thus we should
+    # reimport this module too.
+    if "daphne.server" in sys.modules:
+        del sys.modules["daphne.server"]
+
+    event_loop = asyncio.new_event_loop()
+    asyncioreactor.install(event_loop)
+    asyncio.set_event_loop(event_loop)


### PR DESCRIPTION
This is one of the possible solutions of django/channels#962 I mentioned in [Google Groups](https://groups.google.com/forum/#!topic/django-developers/k8q5M3HCNXE) and the comment in the issue link.

This code closes the event loop inherited from the parent of a `DaphneProcess` and opens a new one, which prevents it from accessing nonexistent Kqueue in BSD-like systems. The [Channels tutorial](https://channels.readthedocs.io/en/latest/tutorial/part_4.html) works fine with MacOS after this patch. (Linux still works.)

Even in Unix-like systems, [this Python issue](https://bugs.python.org/issue21998) warns that `fork()`ing a process running an event loop may cause undesired behavior.

If the `DaphneProcess` is forked while the event loop is running, which should not happen in either system, a RuntimeError will be raised, and the testing will freeze like a MacOS bug. This should be taken into consideration for further development.

P.S. I added that .idea to .gitignore because I debugged Channels with PyCharm. If it is an eyesore, I will remove it.

Closes https://github.com/django/channels/issues/962