### PR TITLE
Support ASGI3

### DIFF
--- a/daphne/cli.py
+++ b/daphne/cli.py
@@ -22,6 +22,8 @@ class ASGI3Middleware:
         self.app = app
 
     def __call__(self, scope):
+        scope.setdefault("asgi", {})
+        scope["asgi"]["version"] = "3.0"
         return functools.partial(self.asgi, scope=scope)
 
     async def asgi(self, receive, send, scope):

--- a/daphne/cli.py
+++ b/daphne/cli.py
@@ -3,6 +3,7 @@ import functools
 import logging
 import sys
 from argparse import ArgumentError, Namespace
+
 from asgiref.compatibility import is_double_callable
 
 from .access import AccessLogGenerator

--- a/daphne/cli.py
+++ b/daphne/cli.py
@@ -132,7 +132,7 @@ class CommandLineInterface(object):
             dest="asgi_protocol",
             help="The version of the ASGI protocol to use",
             default="auto",
-            choices=["asgi2", "asgi3", "auto"]
+            choices=["asgi2", "asgi3", "auto"],
         )
         self.parser.add_argument(
             "--root-path",

--- a/daphne/cli.py
+++ b/daphne/cli.py
@@ -1,5 +1,5 @@
-import asyncio
 import argparse
+import asyncio
 import functools
 import inspect
 import logging

--- a/daphne/cli.py
+++ b/daphne/cli.py
@@ -1,7 +1,5 @@
 import argparse
-import asyncio
 import functools
-import inspect
 import logging
 import sys
 from argparse import ArgumentError, Namespace

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     package_dir={"twisted": "daphne/twisted"},
     packages=find_packages() + ["twisted.plugins"],
     include_package_data=True,
-    install_requires=["twisted>=18.7", "autobahn>=0.18", "asgiref>=3.0.0"],
+    install_requires=["twisted>=18.7", "autobahn>=0.18", "asgiref~=3.0"],
     setup_requires=["pytest-runner"],
     extras_require={
         "tests": ["hypothesis~=3.88", "pytest~=3.10", "pytest-asyncio~=0.8"]

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     package_dir={"twisted": "daphne/twisted"},
     packages=find_packages() + ["twisted.plugins"],
     include_package_data=True,
-    install_requires=["twisted>=18.7", "autobahn>=0.18"],
+    install_requires=["twisted>=18.7", "autobahn>=0.18", "asgiref>=3.0.0"],
     setup_requires=["pytest-runner"],
     extras_require={
         "tests": ["hypothesis~=3.88", "pytest~=3.10", "pytest-asyncio~=0.8"]


### PR DESCRIPTION
Refs https://github.com/django/asgiref/pull/80

Notes:

* I've not yet added tests here - not sure where to do so.
* I figure it makes more sense to go with the more minimal "middleware shim if it's ASGI3", rather than switching the default to ASGI3, and using "middleware shim if it's ASGI2". A follow-up could switch that around at a later date.
* I've taken the auto-detect directly from asgiref. Uvicorn uses a [slightly different approach](https://github.com/encode/uvicorn/blob/master/uvicorn/config.py#L185-L191).