### PR TITLE
Fix some warnings in the tests

### DIFF
--- a/daphne/endpoints.py
+++ b/daphne/endpoints.py
@@ -8,7 +8,7 @@ def build_endpoint_description_strings(
     """
     socket_descriptions = []
     if host and port is not None:
-        host = host.strip("[]").replace(":", "\:")
+        host = host.strip("[]").replace(":", r"\:")
         socket_descriptions.append("tcp:port=%d:interface=%s" % (int(port), host))
     elif any([host, port]):
         raise ValueError("TCP binding requires both port and host kwargs.")


### PR DESCRIPTION
These warnings:
```
daphne/endpoints.py:11
  /home/travis/build/simonw/daphne/daphne/endpoints.py:11: DeprecationWarning: invalid escape sequence \:
    host = host.strip("[]").replace(":", "\:")
tests/test_http_request.py::TestHTTPRequest::test_duplicate_headers
  /home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/hypothesis/internal/validation.py:157: HypothesisDeprecationWarning: You should remove the average_size argument, because it is deprecated and no longer has any effect.  Please open an issue if the default distribution of examples does not work for you.
    since="2018-03-10",
```