### PR TITLE
Add Dockerfile and wrapper for `docker run`.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.7
+
+RUN mkdir /src
+WORKDIR /src
+ADD . /src/
+
+RUN pip install -e .[tests]
+
+CMD ["pytest"]

--- a/docker-tests.sh
+++ b/docker-tests.sh
@@ -1,0 +1,6 @@
+#! /bin/bash
+find . -name "*.pyc" -delete
+
+docker run --rm \
+--mount type=bind,source=`pwd`,target=/src \
+daphne


### PR DESCRIPTION
Adds a basic Dockerfile. (As discussed in #268.)

Build with:

    docker build -t daphne .

The `-t daphne` gives the image the name `daphne` so you can run it easily later.

Do this once to begin, and again if you alter the `venv` at any time. 

Then you can `docker run` to exectute `pytest`:

```
docker run --rm \
--mount type=bind,source=`pwd`,target=/src \
daphne
```

This mounts the Daphne source code from your checkout into the container, so you can test you latest code, rather than the version you built the container with.

In addition the `docker-tests.sh` helper just wraps that `docker run` command, first deleting any .pyc files, so you don’t get a conflict between the host and container.