### PR TITLE
Added support for executing from interpreter.

### DIFF
--- a/daphne/__main__.py
+++ b/daphne/__main__.py
@@ -1,0 +1,3 @@
+from daphne.cli import CommandLineInterface
+
+CommandLineInterface.entrypoint()


### PR DESCRIPTION
For run from python interpreter as module use command:
`python -m daphne [all daphne arguments]`.

This is a very useful function for starting the server in integration mode, for example, in uWSGI.
In various Python installations, the directory with `console_scripts` may be different, and in this run option, it is enough to bind to the interpreter.

May be, you could release it feature in patch-release `2.3.1` because this PR does not change functionality but very needed.