### PR TITLE
Fixed #276 -- Ensured 500 response when app sends malformed headers.

### DIFF
--- a/daphne/server.py
+++ b/daphne/server.py
@@ -219,7 +219,12 @@ class Server(object):
             "disconnected", None
         ):
             return
-        self.check_headers_type(message)
+        try:
+            self.check_headers_type(message)
+        except ValueError:
+            # Ensure to send SOME reply.
+            protocol.basic_error(500, b"Server Error", "Server Error")
+            raise
         # Let the protocol handle it
         protocol.handle_reply(message)
 

--- a/tests/http_base.py
+++ b/tests/http_base.py
@@ -56,12 +56,16 @@ class DaphneTestCase(unittest.TestCase):
             # Return scope, messages, response
             return test_app.get_received() + (response,)
 
-    def run_daphne_raw(self, data, timeout=1):
+    def run_daphne_raw(self, data, *, responses=None, timeout=1):
         """
-        Runs daphne and sends it the given raw bytestring over a socket. Returns what it sends back.
+        Runs Daphne and sends it the given raw bytestring over a socket.
+        Accepts list of response messages the application will reply with.
+        Returns what Daphne sends back.
         """
         assert isinstance(data, bytes)
         with DaphneTestingInstance() as test_app:
+            if responses is not None:
+                test_app.add_send_messages(responses)
             s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             s.settimeout(timeout)
             s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)

--- a/tests/test_http_response.py
+++ b/tests/test_http_response.py
@@ -169,3 +169,21 @@ class TestHTTPResponse(DaphneTestCase):
             str(context.exception),
             "Header value 'True' expected to be `bytes`, but got `<class 'bool'>`",
         )
+
+    def test_headers_type_raw(self):
+        """
+        Daphne returns a 500 error response if the application sends invalid
+        headers.
+        """
+        response = self.run_daphne_raw(
+            b"GET / HTTP/1.0\r\n\r\n",
+            responses=[
+                {
+                    "type": "http.response.start",
+                    "status": 200,
+                    "headers": [["foo", b"bar"]],
+                },
+                {"type": "http.response.body", "body": b""},
+            ],
+        )
+        self.assertTrue(response.startswith(b"HTTP/1.0 500 Internal Server Error"))


### PR DESCRIPTION
Fixes #276.

A consumer sending bad headers like this...

```python
class FaultyHttpConsumer(AsyncHttpConsumer):
    async def handle(self, body):
        print('***before send_response()')
        await self.send_response(200, b"Your response bytes", headers=[
            ("Content-Type", "text/plain"),   # !!!: These should be bytes
        ])
        print('***after send_response()')
```

... will cause no response ever to be sent. The client just waits forever. 

Other clients (targeting a `FunctionalHttpConsumer`) can continue to connect, and are served correctly.

The error is passed back up into the consumer, which stops correctly. 

So (I think) the only real issue is the waiting client and the un-closed connection. 

This PR ensures a response is sent even when `check_headers_type` raises.
