### PR TITLE
Pin hypothesis

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     install_requires=["twisted[tls]>=18.7", "autobahn>=0.18", "asgiref~=3.0"],
     setup_requires=["pytest-runner"],
     extras_require={
-        "tests": ["hypothesis~=4.23", "pytest~=3.10", "pytest-asyncio~=0.8"]
+        "tests": ["hypothesis==4.23", "pytest~=3.10", "pytest-asyncio~=0.8"]
     },
     entry_points={
         "console_scripts": ["daphne = daphne.cli:CommandLineInterface.entrypoint"]


### PR DESCRIPTION
Refs #282.

https://travis-ci.org/django/daphne/jobs/595912612

Requirement already satisfied: attrs>=17.4.0 in /home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages (from twisted) (18.2.0)

hypothesis 4.40.0 has requirement attrs>=19.2.0, but you'll have attrs 18.2.0 which is incompatible.