### PR TITLE
Travis Updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,16 +38,6 @@ jobs:
       dist: xenial
       sudo: required
 
-    - os: osx
-      language: generic
-      python: '3.6'
-      env: TWISTED="twisted"
-      before_install:
-        - eval "$(pyenv init -)"
-        - pyenv install 3.6.5
-        - pyenv global 3.6.5
-      sudo: required
-
     - stage: lint
       install: pip install -U -e .[tests] black pyflakes isort
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,33 +36,6 @@ jobs:
 
     - os: osx
       language: generic
-      python: '3.5'
-      env: TWISTED="twisted==18.7.0"
-      before_install:
-        - eval "$(pyenv init -)"
-        - pyenv install 3.5.5
-        - pyenv global 3.5.5
-      sudo: required
-    - os: osx
-      language: generic
-      python: '3.5'
-      env: TWISTED="twisted"
-      before_install:
-        - eval "$(pyenv init -)"
-        - pyenv install 3.5.5
-        - pyenv global 3.5.5
-      sudo: required
-    - os: osx
-      language: generic
-      python: '3.6'
-      env: TWISTED="twisted==18.7.0"
-      before_install:
-        - eval "$(pyenv init -)"
-        - pyenv install 3.6.5
-        - pyenv global 3.6.5
-      sudo: required
-    - os: osx
-      language: generic
       python: '3.6'
       env: TWISTED="twisted"
       before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,10 @@ jobs:
       env: TWISTED="twisted"
       dist: xenial
       sudo: required
+    - python: '3.8'
+      env: TWISTED="twisted"
+      dist: xenial
+      sudo: required
 
     - os: osx
       language: generic


### PR DESCRIPTION
* Reduced macOS Travis builds to single env.  
  (Slow, and not any benefit in multiple runs.)
* Add testing against Python 3.8. 
* Remove final macOS build (Travis is just too slow.) 