### PR TITLE
Simplify travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ sudo: false
 language: python
 
 python:
+- '3.8'
+- '3.7'
 - '3.6'
 - '3.5'
 
@@ -25,20 +27,8 @@ stages:
 
 jobs:
   include:
-    - python: '3.7'
-      env: TWISTED="twisted==18.7.0"
-      dist: xenial
-      sudo: required
-    - python: '3.7'
-      env: TWISTED="twisted"
-      dist: xenial
-      sudo: required
-    - python: '3.8'
-      env: TWISTED="twisted"
-      dist: xenial
-      sudo: required
-
     - stage: lint
+      python: 3.6
       install: pip install -U -e .[tests] black pyflakes isort
       script:
         - pyflakes daphne tests
@@ -46,6 +36,7 @@ jobs:
         - isort --check-only --diff --recursive daphne tests
 
     - stage: release
+      python: 3.6
       script: skip
       deploy:
         provider: pypi


### PR DESCRIPTION
Not sure if Python 3.6 is the best choice for the `lint` and `release` stage.  It's what was used before.