### PR TITLE
Change the Event Loop to 'Selector' for all platforms

### DIFF
--- a/daphne/server.py
+++ b/daphne/server.py
@@ -1,9 +1,9 @@
 # This has to be done first as Twisted is import-order-sensitive with reactors
 import asyncio  # isort:skip
+import selectors # isort:skip
 import sys  # isort:skip
 import warnings  # isort:skip
 from twisted.internet import asyncioreactor  # isort:skip
-import selectors
 
 selector = selectors.SelectSelector()
 twisted_loop = asyncio.SelectorEventLoop(selector)

--- a/daphne/server.py
+++ b/daphne/server.py
@@ -3,8 +3,11 @@ import asyncio  # isort:skip
 import sys  # isort:skip
 import warnings  # isort:skip
 from twisted.internet import asyncioreactor  # isort:skip
+import selectors
 
-twisted_loop = asyncio.new_event_loop()
+selector = selectors.SelectSelector()
+twisted_loop = asyncio.SelectorEventLoop(selector)
+
 current_reactor = sys.modules.get("twisted.internet.reactor", None)
 if current_reactor is not None:
     if not isinstance(current_reactor, asyncioreactor.AsyncioSelectorReactor):

--- a/daphne/server.py
+++ b/daphne/server.py
@@ -1,6 +1,6 @@
 # This has to be done first as Twisted is import-order-sensitive with reactors
 import asyncio  # isort:skip
-import selectors # isort:skip
+import selectors  # isort:skip
 import sys  # isort:skip
 import warnings  # isort:skip
 from twisted.internet import asyncioreactor  # isort:skip

--- a/daphne/testing.py
+++ b/daphne/testing.py
@@ -2,6 +2,7 @@ import logging
 import multiprocessing
 import os
 import pickle
+import selectors
 import tempfile
 import traceback
 from concurrent.futures import CancelledError
@@ -275,6 +276,6 @@ def _reinstall_reactor():
     if "daphne.server" in sys.modules:
         del sys.modules["daphne.server"]
 
-    event_loop = asyncio.new_event_loop()
+    event_loop = asyncio.SelectorEventLoop(selectors.SelectSelector())
     asyncioreactor.install(event_loop)
     asyncio.set_event_loop(event_loop)


### PR DESCRIPTION
Python 3.8 now returns the ProactorEventLoop on Windows platforms, which does not implement add_writer/add_reader. For now, switch to SelectorEventLoop.