### PR TITLE
Set event loop policy on Windows with Python 3.8+.

### DIFF
--- a/daphne/__init__.py
+++ b/daphne/__init__.py
@@ -1,1 +1,14 @@
+import sys
+
 __version__ = "2.4.1"
+
+
+# Windows on Python 3.8+ uses ProactorEventLoop, which is not compatible with
+# Twisted. Does not implement add_writer/add_reader.
+# See https://bugs.python.org/issue37373
+# and https://twistedmatrix.com/trac/ticket/9766
+PY38_WIN = sys.version_info >= (3, 8) and sys.platform == "win32"
+if PY38_WIN:
+    import asyncio
+
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())


### PR DESCRIPTION
Alternative to #298.

Sets the event loop policy in a single place when importing Daphne (**if** we're on Windows + Python 3.8). 

@Brishen, @chrisbarber — Can you comment/give this a run? Thanks! 