### PR TITLE
Windows 38 event loop policy

### DIFF
--- a/daphne/__init__.py
+++ b/daphne/__init__.py
@@ -1,1 +1,14 @@
+import sys
+
 __version__ = "2.4.1"
+
+
+# Windows on Python 3.8+ uses ProactorEventLoop, which is not compatible with
+# Twisted. Does not implement add_writer/add_reader.
+# See https://bugs.python.org/issue37373
+# and https://twistedmatrix.com/trac/ticket/9766
+PY38_WIN = sys.version_info >= (3, 8) and sys.platform == "win32"
+if PY38_WIN:
+    import asyncio
+
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())


### PR DESCRIPTION
followup to #315 

Thanks to @carltongibson for prioritizing and investigating the win38/proactoreventloop/twisted issue

This attempts to fix empty pickle file issue in the tests which started manifesting after that.