### PR TITLE
Fix compatibility with isort 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ jobs:
       script:
         - pyflakes daphne tests
         - black --check daphne tests
-        - isort --check-only --diff --recursive daphne tests
+        - isort --check-only --diff daphne tests
 
     - stage: release
       python: 3.6

--- a/daphne/testing.py
+++ b/daphne/testing.py
@@ -127,8 +127,8 @@ class DaphneProcess(multiprocessing.Process):
 
         from twisted.internet import reactor
 
-        from .server import Server
         from .endpoints import build_endpoint_description_strings
+        from .server import Server
 
         try:
             # Create the server class
@@ -266,8 +266,8 @@ class TestApplication:
 
 
 def _reinstall_reactor():
-    import sys
     import asyncio
+    import sys
 
     from twisted.internet import asyncioreactor
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ addopts = tests/
 [isort]
 include_trailing_comma = True
 multi_line_output = 3
-known_first_party = channels,daphne,asgiref,channels_redis
+known_first_party = channels,daphne,asgiref,channels_redis,http_base,http_strategies
 line_length = 88
 
 [flake8]


### PR DESCRIPTION
Tests are still failing but this is out of this PR's scope, see django/daphne#322 instead