### PR TITLE
Update README for shell compatibility.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ Daphne supports terminating HTTP/2 connections natively. You'll
 need to do a couple of things to get it working, though. First, you need to
 make sure you install the Twisted ``http2`` and ``tls`` extras::
 
-    pip install -U Twisted[tls,http2]
+    pip install -U 'Twisted[tls,http2]'
 
 Next, because all current browsers only support HTTP/2 when using TLS, you will
 need to start Daphne with TLS turned on, which can be done using the Twisted endpoint syntax::
@@ -124,7 +124,7 @@ Please refer to the
 To run tests, make sure you have installed the ``tests`` extra with the package::
 
     cd daphne/
-    pip install -e .[tests]
+    pip install -e '.[tests]'
     pytest
 
 


### PR DESCRIPTION
Some shells aren't too happy when passing arguments that have brackets.  Using quotes around those arguments here should make it easier for folks to copy and paste these commands around. 😄 