### PR TITLE
Prepare version 3.0 release.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,12 +1,26 @@
+3.0.0 (2020-10-28)
+------------------
+
+* Updates internals to use ASGI v3 throughout. ``asgiref.compatibility`` is
+  used for older applications.
+
+* Consequently, the `--asgi-protocol` command-line option is removed.
+
+* HTTP request bodies are now read, and passed to the application, in chunks.
+
+* Added support for Python 3.9.
+
+* Dropped support for Python 3.5.
+
 2.5.0 (2020-04-15)
 ------------------
 
-* Fixes compatability for twisted when running Python 3.8+ on Windows, by 
-  setting ``asyncio.WindowsSelectorEventLoopPolicy`` as the event loop policy 
-  in this case. 
+* Fixes compatability for twisted when running Python 3.8+ on Windows, by
+  setting ``asyncio.WindowsSelectorEventLoopPolicy`` as the event loop policy
+  in this case.
 
-* The internal ``daphne.testing.TestApplication`` now requires an addition 
-  ``lock`` argument to ``__init__()``. This is expected to be an instance of 
+* The internal ``daphne.testing.TestApplication`` now requires an addition
+  ``lock`` argument to ``__init__()``. This is expected to be an instance of
   ``multiprocessing.Lock``.
 
 2.4.1 (2019-12-18)

--- a/README.rst
+++ b/README.rst
@@ -12,10 +12,6 @@ developed to power Django Channels.
 It supports automatic negotiation of protocols; there's no need for URL
 prefixing to determine WebSocket endpoints versus HTTP endpoints.
 
-*Note:* Daphne 2 is not compatible with Channels 1.x applications, only with
-Channels 2.x and other ASGI applications. Install a 1.x version of Daphne
-for Channels 1.x support.
-
 
 Running
 -------

--- a/daphne/__init__.py
+++ b/daphne/__init__.py
@@ -1,6 +1,6 @@
 import sys
 
-__version__ = "2.5.0"
+__version__ = "3.0.0"
 
 
 # Windows on Python 3.8+ uses ProactorEventLoop, which is not compatible with

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     package_dir={"twisted": "daphne/twisted"},
     packages=find_packages() + ["twisted.plugins"],
     include_package_data=True,
-    install_requires=["twisted[tls]>=18.7", "autobahn>=0.18", "asgiref~=3.2"],
+    install_requires=["twisted[tls]>=18.7", "autobahn>=0.18", "asgiref>=3.2.10,<4"],
     python_requires='>=3.6',
     setup_requires=["pytest-runner"],
     extras_require={


### PR DESCRIPTION
* Bump version number.
* Changelog.
* README.
* Update asgiref dependency specifier to match Django 3.1.