### PR TITLE
Handle asyncio.CancelledError in Server.application_checker

### DIFF
--- a/daphne/server.py
+++ b/daphne/server.py
@@ -277,7 +277,7 @@ class Server(object):
             if application_instance and application_instance.done():
                 try:
                     exception = application_instance.exception()
-                except CancelledError:
+                except (CancelledError, asyncio.CancelledError):
                     # Future cancellation. We can ignore this.
                     pass
                 else:


### PR DESCRIPTION
As of [bpo-32528](https://bugs.python.org/issue32528) (Python 3.8), asyncio.CancelledError is not a subclass of concurrent.futures.CancelledError.

This means that if an asyncio future raises an exception, it won't be caught. Therefore, the exception will bubble past the try-except within the loop in application_checker, resulting in done applications not being cleaned up, and the application_checker task not being queued again.

In situations of high load, this was causing a very alarming memory leak.