### PR TITLE
Only force a default endpoint w/o valid endpoint

### DIFF
--- a/daphne/cli.py
+++ b/daphne/cli.py
@@ -245,10 +245,18 @@ class CommandLineInterface(object):
             # no advanced binding options passed, patch in defaults
             args.host = DEFAULT_HOST
             args.port = DEFAULT_PORT
-        elif args.host and args.port is None:
+        elif args.host and args.port is None and not any([
+            # Checking the other options must be done or else 
+            args.unix_socket,
+            args.file_descriptor is not None,
+            args.socket_strings
+        ]):
             args.port = DEFAULT_PORT
-        elif args.port is not None and not args.host:
-            args.host = DEFAULT_HOST
+        elif args.port is not None and not args.host and not any([
+            args.unix_socket,
+            args.file_descriptor is not None,
+            args.socket_strings
+        ]):
         # Build endpoint description strings from (optional) cli arguments
         endpoints = build_endpoint_description_strings(
             host=args.host,


### PR DESCRIPTION
If you run `daphne --endpoint ssl:8000:privateKey=key.pem:certKey=cert.pem --bind 0.0.0.0  MyApp.asgi:application` in trying to specify that the application should bind to 0.0.0.0, two bindings will be made to the same port, and daphne will never properly start. While I know the `--bind 0.0.0.0` specification is unnecessary, it's certainly confusing to debug and is not intuitive from the standpoint of the programmer trying to use the CLI.