### PR TITLE
cap Twisted dependency below v21

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     package_dir={"twisted": "daphne/twisted"},
     packages=find_packages() + ["twisted.plugins"],
     include_package_data=True,
-    install_requires=["twisted[tls]>=18.7", "autobahn>=0.18", "asgiref>=3.2.10,<4"],
+    install_requires=["twisted[tls]>=18.7,<21", "autobahn>=0.18", "asgiref>=3.2.10,<4"],
     python_requires='>=3.6',
     setup_requires=["pytest-runner"],
     extras_require={


### PR DESCRIPTION
Seems like newly released version of Twisted (21.2.0) has some breaking changes. When I'm trying to start a Django project with Channels I get this error. Downgrading back to previous Twisted version (20.3.0) helps.

```
$ gunicorn yyy.asgi:application -w 4 -k uvicorn.workers.UvicornWorker -b 127.0.0.1:5315
[2021-03-01 10:13:28 +0700] [72519] [INFO] Starting gunicorn 20.0.4
[2021-03-01 10:13:28 +0700] [72519] [INFO] Listening at: http://127.0.0.1:5315 (72519)
[2021-03-01 10:13:28 +0700] [72519] [INFO] Using worker: uvicorn.workers.UvicornWorker
[2021-03-01 10:13:28 +0700] [72562] [INFO] Booting worker with pid: 72562
[2021-03-01 10:13:28 +0700] [72563] [INFO] Booting worker with pid: 72563
[2021-03-01 10:13:28 +0700] [72564] [INFO] Booting worker with pid: 72564
[2021-03-01 03:13:28 +0000] [72562] [ERROR] Exception in worker process
Traceback (most recent call last):
  File "/Users/yed/.pyenv/versions/3.9.1/envs/xxx39/lib/python3.9/site-packages/gunicorn/arbiter.py", line 583, in spawn_worker
    worker.init_process()
  File "/Users/yed/.pyenv/versions/3.9.1/envs/xxx39/lib/python3.9/site-packages/uvicorn/workers.py", line 63, in init_process
    super(UvicornWorker, self).init_process()
  File "/Users/yed/.pyenv/versions/3.9.1/envs/xxx39/lib/python3.9/site-packages/gunicorn/workers/base.py", line 119, in init_process
    self.load_wsgi()
  File "/Users/yed/.pyenv/versions/3.9.1/envs/xxx39/lib/python3.9/site-packages/gunicorn/workers/base.py", line 144, in load_wsgi
    self.wsgi = self.app.wsgi()
  File "/Users/yed/.pyenv/versions/3.9.1/envs/xxx39/lib/python3.9/site-packages/gunicorn/app/base.py", line 67, in wsgi
    self.callable = self.load()
  File "/Users/yed/.pyenv/versions/3.9.1/envs/xxx39/lib/python3.9/site-packages/gunicorn/app/wsgiapp.py", line 49, in load
    return self.load_wsgiapp()
  File "/Users/yed/.pyenv/versions/3.9.1/envs/xxx39/lib/python3.9/site-packages/gunicorn/app/wsgiapp.py", line 39, in load_wsgiapp
    return util.import_app(self.app_uri)
  File "/Users/yed/.pyenv/versions/3.9.1/envs/xxx39/lib/python3.9/site-packages/gunicorn/util.py", line 358, in import_app
    mod = importlib.import_module(module)
  File "/Users/yed/.pyenv/versions/3.9.1/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 790, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/Users/yed/dev/xxx/yyy/asgi.py", line 4, in <module>
    django.setup()
  File "/Users/yed/.pyenv/versions/3.9.1/envs/xxx39/lib/python3.9/site-packages/django/__init__.py", line 24, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/Users/yed/.pyenv/versions/3.9.1/envs/xxx39/lib/python3.9/site-packages/django/apps/registry.py", line 91, in populate
    app_config = AppConfig.create(entry)
  File "/Users/yed/.pyenv/versions/3.9.1/envs/xxx39/lib/python3.9/site-packages/django/apps/config.py", line 116, in create
    mod = import_module(mod_path)
  File "/Users/yed/.pyenv/versions/3.9.1/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 790, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/Users/yed/dev/xxx/channels/apps.py", line 4, in <module>
    import daphne.server
  File "/Users/yed/dev/xxx/daphne/daphne/server.py", line 20, in <module>
    asyncioreactor.install(twisted_loop)
  File "/Users/yed/.pyenv/versions/3.9.1/envs/xxx39/lib/python3.9/site-packages/twisted/internet/asyncioreactor.py", line 307, in install
    reactor = AsyncioSelectorReactor(eventloop)
  File "/Users/yed/.pyenv/versions/3.9.1/envs/xxx39/lib/python3.9/site-packages/twisted/internet/asyncioreactor.py", line 60, in __init__
    raise TypeError(
TypeError: SelectorEventLoop required, instead got: <uvloop.Loop running=False closed=False debug=False>
[2021-03-01 03:13:28 +0000] [72562] [INFO] Worker exiting (pid: 72562)
[2021-03-01 10:13:28 +0700] [72565] [INFO] Booting worker with pid: 72565
[2021-03-01 10:13:29 +0700] [72519] [INFO] Shutting down: Master
[2021-03-01 10:13:29 +0700] [72519] [INFO] Reason: Worker failed to boot
```
