### PR TITLE
Use partial() to wrap Server.handle_reply()

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+* Fixed a bug where ``send`` passed to applications wasn't a true async
+  function but a lambda wrapper, preventing it from being used with
+  ``asgiref.sync.async_to_sync()``.
+
 3.0.1 (2020-11-12)
 ------------------
 

--- a/daphne/server.py
+++ b/daphne/server.py
@@ -22,6 +22,7 @@ else:
 import logging
 import time
 from concurrent.futures import CancelledError
+from functools import partial
 
 from twisted.internet import defer, reactor
 from twisted.internet.endpoints import serverFromString
@@ -203,7 +204,7 @@ class Server(object):
         application_instance = self.application(
             scope=scope,
             receive=input_queue.get,
-            send=lambda message: self.handle_reply(protocol, message),
+            send=partial(self.handle_reply, protocol),
         )
         # Run it, and stash the future for later checking
         if protocol not in self.connections:


### PR DESCRIPTION
Fixes #362.