### PR TITLE
Lint with pre-commit

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,24 @@
+name: pre-commit
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - uses: pre-commit/action@v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,17 +31,3 @@ jobs:
         run: |
           ENV_PREFIX=$(tr -C -d "0-9" <<< "${{ matrix.python-version }}")
           TOXENV=$(tox --listenvs | grep "^py$ENV_PREFIX" | tr '\n' ',') python -m tox
-
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip tox
-      - name: Run lint
-        run: tox -e qa

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+repos:
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.11.0
+    hooks:
+      - id: pyupgrade
+        args: [--py36-plus]
+  - repo: https://github.com/psf/black
+    rev: 20.8b1
+    hooks:
+      - id: black
+        language_version: python3
+  - repo: https://github.com/pycqa/isort
+    rev: 5.8.0
+    hooks:
+      - id: isort
+  - repo: https://github.com/PyCQA/flake8
+    rev: 3.9.0
+    hooks:
+      - id: flake8
+        additional_dependencies:
+          - flake8-bugbear

--- a/daphne/access.py
+++ b/daphne/access.py
@@ -1,7 +1,7 @@
 import datetime
 
 
-class AccessLogGenerator(object):
+class AccessLogGenerator:
     """
     Object that implements the Daphne "action logger" internal interface in
     order to provide an access log in something resembling NCSA format.

--- a/daphne/cli.py
+++ b/daphne/cli.py
@@ -16,7 +16,7 @@ DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8000
 
 
-class CommandLineInterface(object):
+class CommandLineInterface:
     """
     Acts as the main CLI entry point for running the server.
     """
@@ -258,7 +258,7 @@ class CommandLineInterface(object):
         )
         endpoints = sorted(args.socket_strings + endpoints)
         # Start the server
-        logger.info("Starting server at %s" % (", ".join(endpoints),))
+        logger.info("Starting server at {}".format(", ".join(endpoints)))
         self.server = self.server_class(
             application=application,
             endpoints=endpoints,

--- a/daphne/server.py
+++ b/daphne/server.py
@@ -34,7 +34,7 @@ from .ws_protocol import WebSocketFactory
 logger = logging.getLogger(__name__)
 
 
-class Server(object):
+class Server:
     def __init__(
         self,
         application,

--- a/daphne/twisted/plugins/fd_endpoint.py
+++ b/daphne/twisted/plugins/fd_endpoint.py
@@ -7,7 +7,7 @@ from zope.interface import implementer
 
 
 @implementer(IPlugin, IStreamServerEndpointStringParser)
-class _FDParser(object):
+class _FDParser:
     prefix = "fd"
 
     def _parseServer(self, reactor, fileno, domain=socket.AF_INET):

--- a/daphne/ws_protocol.py
+++ b/daphne/ws_protocol.py
@@ -297,7 +297,7 @@ class WebSocketProtocol(WebSocketServerProtocol):
         return id(self) == id(other)
 
     def __repr__(self):
-        return "<WebSocketProtocol client=%r path=%r>" % (self.client_addr, self.path)
+        return f"<WebSocketProtocol client={self.client_addr!r} path={self.path!r}>"
 
 
 class WebSocketFactory(WebSocketServerFactory):
@@ -318,7 +318,7 @@ class WebSocketFactory(WebSocketServerFactory):
         Builds protocol instances. We use this to inject the factory object into the protocol.
         """
         try:
-            protocol = super(WebSocketFactory, self).buildProtocol(addr)
+            protocol = super().buildProtocol(addr)
             protocol.factory = self
             return protocol
         except Exception:

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     packages=find_packages() + ["twisted.plugins"],
     include_package_data=True,
     install_requires=["twisted[tls]>=18.7", "autobahn>=0.18", "asgiref>=3.2.10,<4"],
-    python_requires='>=3.6',
+    python_requires=">=3.6",
     setup_requires=["pytest-runner"],
     extras_require={
         "tests": ["hypothesis==4.23", "pytest~=3.10", "pytest-asyncio~=0.8"]

--- a/tests/http_base.py
+++ b/tests/http_base.py
@@ -182,7 +182,7 @@ class DaphneTestCase(unittest.TestCase):
         if response.status != 101:
             raise RuntimeError("WebSocket upgrade did not result in status code 101")
         # Prepare headers for subprotocol searching
-        response_headers = dict((n.lower(), v) for n, v in response.getheaders())
+        response_headers = {n.lower(): v for n, v in response.getheaders()}
         response.read()
         assert not response.closed
         # Return the raw socket and any subprotocol
@@ -252,7 +252,7 @@ class DaphneTestCase(unittest.TestCase):
         """
         try:
             socket.inet_aton(address)
-        except socket.error:
+        except OSError:
             self.fail("'%s' is not a valid IP address." % address)
 
     def assert_key_sets(self, required_keys, optional_keys, actual_keys):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,3 @@
-# coding: utf8
-
 import logging
 from argparse import ArgumentError
 from unittest import TestCase

--- a/tests/test_http_request.py
+++ b/tests/test_http_request.py
@@ -1,5 +1,3 @@
-# coding: utf8
-
 import collections
 from urllib import parse
 

--- a/tests/test_http_response.py
+++ b/tests/test_http_response.py
@@ -1,5 +1,3 @@
-# coding: utf8
-
 import http_strategies
 from http_base import DaphneTestCase
 from hypothesis import given, settings

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,3 @@
-# coding: utf8
-
 from unittest import TestCase
 
 from twisted.web.http_headers import Headers

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -1,5 +1,3 @@
-# coding: utf8
-
 import collections
 import time
 from urllib import parse

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
     py{36,37,38,39}-twisted{187,latest}
-    qa
 
 [testenv]
 usedevelop = true
@@ -11,13 +10,3 @@ commands =
 deps =
     twisted187: twisted==18.7.0
     twistedlatest: twisted>=20.3.0
-
-[testenv:qa]
-deps =
-    black
-    flake8
-    isort
-commands =
-    flake8 daphne tests
-    black --check daphne tests
-    isort --check-only --diff daphne tests


### PR DESCRIPTION
* Move existing tox qa hooks into pre-commit.
* Set up GitHub Action based on https://github.com/pre-commit/action/ (we could also use https://pre-commit.ci ).
* Add `pyupgrade` to drop old Python syntax.
* Add `flake8-bugbear` plugin to prevent flake8 errors.