### PR TITLE
Removed deprecated —ws-protocols CLI option.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -39,6 +39,8 @@ This is a beta release to allow testing compatibility with the upcoming Channels
     ...
   ]
 
+* Removed deprecated ``--ws_protocols`` CLI option.
+
 3.0.2 (2021-04-07)
 ------------------
 

--- a/daphne/cli.py
+++ b/daphne/cli.py
@@ -114,13 +114,6 @@ class CommandLineInterface:
             default=10,
         )
         self.parser.add_argument(
-            "--ws-protocol",
-            nargs="*",
-            dest="ws_protocols",
-            help="The WebSocket protocols you wish to support",
-            default=None,
-        )
-        self.parser.add_argument(
             "--root-path",
             dest="root_path",
             help="The setting for the ASGI root_path variable",
@@ -280,7 +273,6 @@ class CommandLineInterface:
             action_logger=AccessLogGenerator(access_log_stream)
             if access_log_stream
             else None,
-            ws_protocols=args.ws_protocols,
             root_path=args.root_path,
             verbosity=args.verbosity,
             proxy_forwarded_address_header=self._get_forwarded_host(args=args),

--- a/daphne/server.py
+++ b/daphne/server.py
@@ -65,8 +65,6 @@ class Server:
         application_close_timeout=10,
         ready_callable=None,
         server_name="daphne",
-        # Deprecated and does not work, remove in version 2.2
-        ws_protocols=None,
     ):
         self.application = application
         self.endpoints = endpoints or []


### PR DESCRIPTION
`--ws-protocol` should be removed.