### PR TITLE
Pin twisted and autobahn version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     package_dir={"twisted": "daphne/twisted"},
     packages=find_packages() + ["twisted.plugins"],
     include_package_data=True,
-    install_requires=["twisted[tls]>=18.7", "autobahn>=0.18", "asgiref>=3.2.10,<4"],
+    install_requires=["twisted[tls]>=18.7,<22", "autobahn>=0.18,<22", "asgiref>=3.2.10,<4"],
     python_requires=">=3.6",
     setup_requires=["pytest-runner"],
     extras_require={


### PR DESCRIPTION
to prevent breaking major changes from coming in by surprise and causing bugs. The lack of pinning has caused bugs for us with other packages in the past.