### PR TITLE
Unpinned test dependencies.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,9 +25,7 @@ setup(
     install_requires=["twisted[tls]>=18.7", "autobahn>=0.18", "asgiref>=3.2.10,<4"],
     python_requires=">=3.6",
     setup_requires=["pytest-runner"],
-    extras_require={
-        "tests": ["hypothesis", "pytest", "pytest-asyncio"]
-    },
+    extras_require={"tests": ["hypothesis", "pytest", "pytest-asyncio"]},
     entry_points={
         "console_scripts": ["daphne = daphne.cli:CommandLineInterface.entrypoint"]
     },


### PR DESCRIPTION
Tests pass locally with latest versions. If they go well across CI, there's no need to keep them pinned to outdated versions.