### PR TITLE
Set a default `Server` header for HTTP responses

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,7 +11,14 @@ Unreleased
   range of versions does not represent a good use of maintainer time. Going
   forward the latest Twisted version will be required.
 
-* Added `log-fmt` CLI argument.
+* Set ``daphne`` as default ``Server`` header.
+
+  This can be configured with the ``--server-name`` CLI argument.
+
+  Added the new ``--no-server-name`` CLI argument to disable the ``Server``
+  header, which is equivalent to ``--server-name=` (an empty name).
+
+* Added ``--log-fmt`` CLI argument.
 
 3.0.2 (2021-04-07)
 ------------------

--- a/daphne/cli.py
+++ b/daphne/cli.py
@@ -93,7 +93,7 @@ class CommandLineInterface:
         self.parser.add_argument(
             "--log-fmt",
             help="Log format to use",
-            default="%(asctime)-15s %(levelname)-8s %(message)s"
+            default="%(asctime)-15s %(levelname)-8s %(message)s",
         )
         self.parser.add_argument(
             "--ping-interval",
@@ -162,7 +162,10 @@ class CommandLineInterface:
             "--server-name",
             dest="server_name",
             help="specify which value should be passed to response header Server attribute",
-            default="Daphne",
+            default="daphne",
+        )
+        self.parser.add_argument(
+            "--no-server-name", dest="server_name", action="store_const", const=""
         )
 
         self.server = None

--- a/daphne/http_protocol.py
+++ b/daphne/http_protocol.py
@@ -249,8 +249,8 @@ class WebRequest(http.Request):
             # Write headers
             for header, value in message.get("headers", {}):
                 self.responseHeaders.addRawHeader(header, value)
-            if self.server.server_name and self.server.server_name.lower() != "daphne":
-                self.setHeader(b"server", self.server.server_name.encode("utf-8"))
+            if self.server.server_name and not self.responseHeaders.hasHeader("server"):
+                self.setHeader(b"server", self.server.server_name.encode())
             logger.debug(
                 "HTTP %s response started for %s", message["status"], self.client_addr
             )

--- a/daphne/server.py
+++ b/daphne/server.py
@@ -56,7 +56,7 @@ class Server:
         websocket_handshake_timeout=5,
         application_close_timeout=10,
         ready_callable=None,
-        server_name="Daphne",
+        server_name="daphne",
         # Deprecated and does not work, remove in version 2.2
         ws_protocols=None,
     ):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -240,3 +240,18 @@ class TestCLIInterface(TestCase):
             exc.exception.message,
             "--proxy-headers has to be passed for this parameter.",
         )
+
+    def test_custom_servername(self):
+        """
+        Passing `--server-name` will set the default server header
+        from 'daphne' to the passed one.
+        """
+        self.assertCLI([], {"server_name": "daphne"})
+        self.assertCLI(["--server-name", ""], {"server_name": ""})
+        self.assertCLI(["--server-name", "python"], {"server_name": "python"})
+
+    def test_no_servername(self):
+        """
+        Passing `--no-server-name` will set server name to '' (empty string)
+        """
+        self.assertCLI(["--no-server-name"], {"server_name": ""})

--- a/tests/test_http_response.py
+++ b/tests/test_http_response.py
@@ -13,9 +13,12 @@ class TestHTTPResponse(DaphneTestCase):
         Lowercases and sorts headers, and strips transfer-encoding ones.
         """
         return sorted(
-            (name.lower(), value.strip())
-            for name, value in headers
-            if name.lower() != b"transfer-encoding"
+            [(b"server", b"daphne")]
+            + [
+                (name.lower(), value.strip())
+                for name, value in headers
+                if name.lower() not in (b"server", b"transfer-encoding")
+            ]
         )
 
     def encode_headers(self, headers):


### PR DESCRIPTION
Fixes : #395 