### PR TITLE
Set default attributes on WebRequest

### DIFF
--- a/daphne/http_protocol.py
+++ b/daphne/http_protocol.py
@@ -50,6 +50,8 @@ class WebRequest(http.Request):
     )  # Shorten it a bit, bytes wise
 
     def __init__(self, *args, **kwargs):
+        self.client_addr = None
+        self.server_addr = None
         try:
             http.Request.__init__(self, *args, **kwargs)
             # Easy server link
@@ -77,9 +79,6 @@ class WebRequest(http.Request):
                 # requires unicode string.
                 self.client_addr = [str(self.client.host), self.client.port]
                 self.server_addr = [str(self.host.host), self.host.port]
-            else:
-                self.client_addr = None
-                self.server_addr = None
 
             self.client_scheme = "https" if self.isSecure() else "http"
 

--- a/tests/test_http_protocol.py
+++ b/tests/test_http_protocol.py
@@ -1,0 +1,49 @@
+import unittest
+
+from daphne.http_protocol import WebRequest
+
+
+class MockServer:
+    """
+    Mock server object for testing.
+    """
+
+    def protocol_connected(self, *args, **kwargs):
+        pass
+
+
+class MockFactory:
+    """
+    Mock factory object for testing.
+    """
+
+    def __init__(self):
+        self.server = MockServer()
+
+
+class MockChannel:
+    """
+    Mock channel object for testing.
+    """
+
+    def __init__(self):
+        self.factory = MockFactory()
+        self.transport = None
+
+    def getPeer(self, *args, **kwargs):
+        return "peer"
+
+    def getHost(self, *args, **kwargs):
+        return "host"
+
+
+class TestHTTPProtocol(unittest.TestCase):
+    """
+    Tests the HTTP protocol classes.
+    """
+
+    def test_web_request_initialisation(self):
+        channel = MockChannel()
+        request = WebRequest(channel)
+        self.assertIsNone(request.client_addr)
+        self.assertIsNone(request.server_addr)


### PR DESCRIPTION
Moves the problematic attributes initialization to the __init__ of the WebRequest class to provide the default None values.
A regression test checking whether the default values set is also added.
Closes #402 

Test results:
```
pytest
=========================================================================================== test session starts ============================================================================================
platform linux -- Python 3.7.4, pytest-7.0.1, pluggy-1.0.0
rootdir: /home/marcin/programming/daphne, configfile: setup.cfg, testpaths: tests
plugins: hypothesis-6.36.2, asyncio-0.18.1
asyncio: mode=legacy
collected 58 items                                                                                                                                                                                         

tests/test_cli.py ............                                                                                                                                                                       [ 20%]
tests/test_http_protocol.py .                                                                                                                                                                        [ 22%]
tests/test_http_request.py ..............                                                                                                                                                            [ 46%]
tests/test_http_response.py .........                                                                                                                                                                [ 62%]
tests/test_utils.py ............                                                                                                                                                                     [ 82%]
tests/test_websocket.py ..........                                                                                                                                                                   [100%]

============================================================================================= warnings summary =============================================================================================
.env/lib/python3.7/site-packages/pytest_asyncio/plugin.py:191
  /home/marcin/programming/daphne/.env/lib/python3.7/site-packages/pytest_asyncio/plugin.py:191: DeprecationWarning: The 'asyncio_mode' default value will change to 'strict' in future, please explicitly use 'asyncio_mode=strict' or 'asyncio_mode=auto' in pytest configuration file.
    config.issue_config_time_warning(LEGACY_MODE, stacklevel=2)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
====================================================================================== 58 passed, 1 warning in 15.02s ======================================================================================
```

Black:
```
$ black tests/ daphne/
All done! ✨ 🍰 ✨
19 files left unchanged.
```

Isort:
```
$ isort --check-only --diff  ./daphne ./tests
$ echo $?
0
```