### PR TITLE
Added argument to change log format

### DIFF
--- a/daphne/__init__.py
+++ b/daphne/__init__.py
@@ -1,6 +1,6 @@
 import sys
 
-__version__ = "3.0.2"
+__version__ = "3.0.3"
 
 
 # Windows on Python 3.8+ uses ProactorEventLoop, which is not compatible with

--- a/daphne/cli.py
+++ b/daphne/cli.py
@@ -91,6 +91,11 @@ class CommandLineInterface:
             default=None,
         )
         self.parser.add_argument(
+            "--log-fmt",
+            help="Log format to use",
+            default="%(asctime)-15s %(levelname)-8s %(message)s"
+        )
+        self.parser.add_argument(
             "--ping-interval",
             type=int,
             help="The number of seconds a WebSocket must be idle before a keepalive ping is sent",
@@ -215,7 +220,7 @@ class CommandLineInterface:
                 2: logging.DEBUG,
                 3: logging.DEBUG,  # Also turns on asyncio debug
             }[args.verbosity],
-            format="%(asctime)-15s %(levelname)-8s %(message)s",
+            format=args.log_fmt,
         )
         # If verbosity is 1 or greater, or they told us explicitly, set up access log
         access_log_stream = None


### PR DESCRIPTION
The current `log-format` is hardcoded into the application, which causes issues with my JSON log parsers as the format written to the stdout/stderr is not JSON.

Current Behavior
```
2022-04-08 15:50:42,351 INFO     {'request_id': '814cee1c-7a72-492d-b630-340afb0d76ea', 'user_id': None, 'ip': '65.49.36.22', 'request': 'GET /health/ping/', 'user_agent': 'kube-probe/1.20', 'event': 'request_started', 'timestamp': '2022-04-08T15:50:42.350996Z', 'logger': 'django_structlog.middlewares.request', 'level': 'info'}
```

The logline gets appended with `DateTime` and `log level` outside the scope of my JSON which is not desirable for me.

I have added a simple CLI argument that can be overridden to pass custom formats which are then written to the destination. The argument still keeps the current implementation intact and allows a user to change the format.