### PR TITLE
Bumped version and changelog for 4.0b1 release.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,8 @@
-Unreleased
-----------
+4.0.0b1 (2022-08-25)
+--------------------
+
+This is a beta release to allow testing compatibility with the upcoming Channels
+4.0.
 
 * Dropped support for Python 3.6.
 

--- a/daphne/__init__.py
+++ b/daphne/__init__.py
@@ -1,6 +1,6 @@
 import sys
 
-__version__ = "3.0.2"
+__version__ = "4.0.0b1"
 
 
 # Windows on Python 3.8+ uses ProactorEventLoop, which is not compatible with


### PR DESCRIPTION
This is for a beta release to allow testing compatibility with the upcoming Channels
 4.0.