### PR TITLE
Make DaphneProcess pickleable

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -41,6 +41,9 @@ This is a beta release to allow testing compatibility with the upcoming Channels
 
 * Removed deprecated ``--ws_protocols`` CLI option.
 
+* Made the ``DaphneProcess`` tests helper class compatible with the ``spawn``
+  process start method, which is used on macOS and Windows.
+
 3.0.2 (2021-04-07)
 ------------------
 

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -288,7 +288,7 @@ async def cancelling_application(scope, receive, send):
     from twisted.internet import reactor
 
     # Stop the server after a short delay so that the teardown is run.
-    reactor.callLater(2, lambda: reactor.stop())
+    reactor.callLater(2, reactor.stop)
     await send({"type": "websocket.accept"})
     raise asyncio.CancelledError()
 


### PR DESCRIPTION
Part of a fix for https://github.com/django/channels/issues/1921.

Make `DaphneProcess` pickleable by:

1. Changing `application` argument to `get_application`, a callable that returns an application. If this is pickleable, the process will be.
2. Removing clever use of `lambda` for plain-old `None` pattern.