### PR TITLE
Run tests against Python 3.11 and add trove classifier

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,7 @@ jobs:
         - "3.8"
         - "3.9"
         - "3.10"
+        - "3.11"
 
     steps:
       - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Internet :: WWW/HTTP",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{37,38,39,310}
+    py{37,38,39,310,311}
 [testenv]
 usedevelop = true
 extras = tests


### PR DESCRIPTION
Python 3.11.0 has been released on 2022-10-24, see https://pythoninsider.blogspot.com/2022/10/python-3110-is-now-available.html

~Python 3.11 is not yet available on GitHub actions.  I'll mark the PR as ready for review once it's available.  See actions/runner-images#6459~
Looks like it was added since I last checked.  ref actions/python-versions#193