### PR TITLE
Upgrade to tox 4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel
-          python -m pip install --upgrade tox tox-py
+          python -m pip install --upgrade 'tox>=4.0.0rc3'
 
       - name: Run tox targets for ${{ matrix.python-version }}
-        run: tox --py current
+        run: tox run -f py$(echo ${{ matrix.python-version }} | tr -d .)


### PR DESCRIPTION
tox 4 final is expected shortly: https://fosstodon.org/@gaborbernat/109428598380006519

tox-py no longer works with it, but that’s okay since the new `-f` factor option fills the need to run Python 3.X tests in the Python 3.X CI run. I documented this pattern in the package install instructions: https://github.com/adamchainz/tox-py/#installation . Plus, I’ve already changed all the projects I maintain to use it, for example: https://github.com/adamchainz/django-htmx/pull/296