### PR TITLE
Double quotes during pip

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ Daphne supports terminating HTTP/2 connections natively. You'll
 need to do a couple of things to get it working, though. First, you need to
 make sure you install the Twisted ``http2`` and ``tls`` extras::
 
-    pip install -U 'Twisted[tls,http2]'
+    pip install -U "Twisted[tls,http2]"
 
 Next, because all current browsers only support HTTP/2 when using TLS, you will
 need to start Daphne with TLS turned on, which can be done using the Twisted endpoint syntax::


### PR DESCRIPTION
Single quotes return => ERROR: Invalid requirement: "'Twisted[tls,http2]'" on windows