### PR TITLE
Convert Access Log Generator to use Python logging

### DIFF
--- a/daphne/cli.py
+++ b/daphne/cli.py
@@ -228,6 +228,8 @@ class CommandLineInterface:
         elif args.verbosity >= 1:
             access_log_stream = sys.stdout
 
+        access_logger = AccessLogGenerator(access_log_stream) if access_log_stream else None
+
         # Import application
         sys.path.insert(0, ".")
         application = import_by_path(args.application)
@@ -270,7 +272,7 @@ class CommandLineInterface:
             websocket_connect_timeout=args.websocket_connect_timeout,
             websocket_handshake_timeout=args.websocket_connect_timeout,
             application_close_timeout=args.application_close_timeout,
-            action_logger=AccessLogGenerator(access_log_stream)
+            action_logger=access_logger
             if access_log_stream
             else None,
             root_path=args.root_path,


### PR DESCRIPTION
Commits to move forward #116.  Convert the access log to use the python logging framework.  Also pass data as named components to make it easier for JSON formatting