### PR TITLE
ws_protocol: Log when WebSocket is killed by Daphne

### DIFF
--- a/daphne/ws_protocol.py
+++ b/daphne/ws_protocol.py
@@ -279,11 +279,13 @@ class WebSocketProtocol(WebSocketServerProtocol):
             self.duration() > self.server.websocket_timeout
             and self.server.websocket_timeout >= 0
         ):
+            logger.warning("WebSocket %s took too long and was killed.", self.client_addr)
             self.serverClose()
         # Ping check
         # If we're still connecting, deny the connection
         if self.state == self.STATE_CONNECTING:
             if self.duration() > self.server.websocket_connect_timeout:
+                logger.warning("WebSocket %s connection took too long and was killed.", self.client_addr)
                 self.serverReject()
         elif self.state == self.STATE_OPEN:
             if (time.time() - self.last_ping) > self.server.ping_interval:


### PR DESCRIPTION
Similar log already exists in the rest of the application. It would help to trace some unexplained websocket disconnection.