### PR TITLE
Ignored flake8-bugbear B036.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ tests =
 
 [flake8]
 exclude = venv/*,tox/*,docs/*,testproject/*,js_client/*,.eggs/*
-extend-ignore = E123, E128, E266, E402, W503, E731, W601
+extend-ignore = E123, E128, E266, E402, W503, E731, W601, B036
 max-line-length = 120
 
 [isort]


### PR DESCRIPTION
"except BaseException: without re-raising" used in testing.py