### PR TITLE
Fix twisted.plugin install

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,9 @@ classifiers =
 [options]
 package_dir =
     twisted=daphne/twisted
-packages = find:
+packages =
+    daphne
+    twisted.plugins
 include_package_data = True
 install_requires =
     asgiref>=3.5.2,<4


### PR DESCRIPTION
Explicitly list packages so `twisted.plugins` will be included.
Fixes #506 