### PR TITLE
Fix package missing management folder(#508)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ package_dir =
     twisted=daphne/twisted
 packages =
     daphne
+    daphne.management
     twisted.plugins
 include_package_data = True
 install_requires =


### PR DESCRIPTION
In `setup.cfg`

`packages = find:` was changed to
```
packages =
    daphne    
    twisted.plugins
```

When manually list packages, should enumerate all the packages

```
packages =
    daphne
    daphne.management
    twisted.plugins
```

