### PR TITLE
Explicitly flush when writing access log entries

### DIFF
--- a/daphne/access.py
+++ b/daphne/access.py
@@ -68,3 +68,4 @@ class AccessLogGenerator:
                 length or "-",
             )
         )
+        self.stream.flush()

--- a/daphne/cli.py
+++ b/daphne/cli.py
@@ -224,7 +224,7 @@ class CommandLineInterface:
             if args.access_log == "-":
                 access_log_stream = sys.stdout
             else:
-                access_log_stream = open(args.access_log, "a", 1)
+                access_log_stream = open(args.access_log, "a")
         elif args.verbosity >= 1:
             access_log_stream = sys.stdout
 


### PR DESCRIPTION
daphne 1.0.0 arranged to flush access logs immediately (#53, #54), but only when logging to a file.  It's often convenient to log to stdout instead and rely on the systemd journal, but at the moment that results in access logs being unhelpfully block-buffered.  Explicitly flush entries so that this works regardless of the logging destination.