### PR TITLE
Include test support files in sdist

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,9 @@
+4.1.3 (to be released)
+------------------
+
+* Removed unused pytest-runner
+* Fixed sdist file to ensure it includes all tests
+
 4.1.2 (2024-04-11)
 ------------------
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include LICENSE
+recursive-include tests *.py

--- a/daphne/__init__.py
+++ b/daphne/__init__.py
@@ -1,6 +1,6 @@
 import sys
 
-__version__ = "4.1.2"
+__version__ = "4.1.3"
 
 
 # Windows on Python 3.8+ uses ProactorEventLoop, which is not compatible with


### PR DESCRIPTION
Ref: https://setuptools.pypa.io/en/latest/deprecated/distutils/sourcedist.html#specifying-the-files-to-distribute

I also went ahead and started preparing release notes for 4.1.3

Closes: https://github.com/django/daphne/issues/522