### PR TITLE
Target py39-plus with pyupgrade.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: v3.17.0
     hooks:
       - id: pyupgrade
-        args: [--py38-plus]
+        args: [--py39-plus]
   - repo: https://github.com/psf/black
     rev: 24.10.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.17.0
+    rev: v3.19.0
     hooks:
       - id: pyupgrade
         args: [--py39-plus]


### PR DESCRIPTION
I noticed that the minimum Python version is now 3.9. The first commit updates the pyupgrade setting for this.

While here I also ran pre-commit autoupdate -- just the one change, and as it happens that was to pyupgrade as well. 