### PR TITLE
allow assigning a port in DaphneProcess

### DIFF
--- a/daphne/testing.py
+++ b/daphne/testing.py
@@ -126,7 +126,9 @@ class DaphneProcess(multiprocessing.Process):
     port it ends up listening on back to the parent process.
     """
 
-    def __init__(self, host, get_application, kwargs=None, setup=None, teardown=None, port=None):
+    def __init__(
+        self, host, get_application, kwargs=None, setup=None, teardown=None, port=None
+    ):
         super().__init__()
         self.host = host
         self.get_application = get_application
@@ -153,7 +155,9 @@ class DaphneProcess(multiprocessing.Process):
 
         try:
             # Create the server class
-            endpoints = build_endpoint_description_strings(host=self.host, port=self.port.value)
+            endpoints = build_endpoint_description_strings(
+                host=self.host, port=self.port.value
+            )
             self.server = Server(
                 application=application,
                 endpoints=endpoints,

--- a/daphne/testing.py
+++ b/daphne/testing.py
@@ -126,14 +126,14 @@ class DaphneProcess(multiprocessing.Process):
     port it ends up listening on back to the parent process.
     """
 
-    def __init__(self, host, get_application, kwargs=None, setup=None, teardown=None):
+    def __init__(self, host, get_application, kwargs=None, setup=None, teardown=None, port=None):
         super().__init__()
         self.host = host
         self.get_application = get_application
         self.kwargs = kwargs or {}
         self.setup = setup
         self.teardown = teardown
-        self.port = multiprocessing.Value("i")
+        self.port = multiprocessing.Value("i", port if port is not None else 0)
         self.ready = multiprocessing.Event()
         self.errors = multiprocessing.Queue()
 
@@ -153,7 +153,7 @@ class DaphneProcess(multiprocessing.Process):
 
         try:
             # Create the server class
-            endpoints = build_endpoint_description_strings(host=self.host, port=0)
+            endpoints = build_endpoint_description_strings(host=self.host, port=self.port.value)
             self.server = Server(
                 application=application,
                 endpoints=endpoints,


### PR DESCRIPTION
Needed changes for original idea https://github.com/django/channels/discussions/2135 and ChannelsLiveServerTestCase updates: https://github.com/django/channels/pull/2136#issue-2867092532

Allows DaphneProcess to accept a port. Since I'm not entirely sure what else uses DaphneProcess, I opted to make the parameter optional and at the end of the init function.

 





