### PR TITLE
Add non-zero exit code to CLI for startup errors.

### DIFF
--- a/daphne/cli.py
+++ b/daphne/cli.py
@@ -289,3 +289,5 @@ class CommandLineInterface:
             server_name=args.server_name,
         )
         self.server.run()
+        if self.server.abort_start:
+            exit(1)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -80,6 +80,7 @@ class TestCLIInterface(TestCase):
             """
             Mock server object for testing.
             """
+
             abort_start = False
 
             def __init__(self, **kwargs):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -80,6 +80,7 @@ class TestCLIInterface(TestCase):
             """
             Mock server object for testing.
             """
+            abort_start = False
 
             def __init__(self, **kwargs):
                 self.init_kwargs = kwargs


### PR DESCRIPTION
Fixes #552.