### PR TITLE
Feature, Add ability to use workers

### DIFF
--- a/daphne/cli.py
+++ b/daphne/cli.py
@@ -160,6 +160,13 @@ class CommandLineInterface:
         self.parser.add_argument(
             "--no-server-name", dest="server_name", action="store_const", const=""
         )
+        self.parser.add_argument(
+            "-w",
+            "--workers",
+            type=int,
+            help="Number of worker processes to spawn",
+            default=1,
+        )
 
         self.server = None
 
@@ -287,5 +294,6 @@ class CommandLineInterface:
                 "X-Forwarded-Proto" if args.proxy_headers else None
             ),
             server_name=args.server_name,
+            workers=args.workers,
         )
         self.server.run()

--- a/daphne/management/commands/runserver.py
+++ b/daphne/management/commands/runserver.py
@@ -85,6 +85,14 @@ class Command(RunserverCommand):
             dest="insecure_serving",
             help="Allows serving static files even if DEBUG is False.",
         )
+        parser.add_argument(
+            "--workers",
+            action="store",
+            dest="workers",
+            type=int,
+            default=1,
+            help="Number of worker processes to spawn (default: 1)",
+        )
 
     def handle(self, *args, **options):
         self.http_timeout = options.get("http_timeout", None)
@@ -144,6 +152,7 @@ class Command(RunserverCommand):
                 http_timeout=self.http_timeout,
                 root_path=getattr(settings, "FORCE_SCRIPT_NAME", "") or "",
                 websocket_handshake_timeout=self.websocket_handshake_timeout,
+                workers=options["workers"],
             ).run()
             logger.debug("Daphne exited")
         except KeyboardInterrupt:

--- a/tests/http_base.py
+++ b/tests/http_base.py
@@ -282,3 +282,14 @@ class DaphneTestCase(unittest.TestCase):
         self.assertIsInstance(address, str)
         self.assert_is_ip_address(address)
         self.assertIsInstance(port, int)
+
+    def test_multiple_workers(self):
+        """
+        Tests that the server can start with multiple workers.
+        """
+        with DaphneTestingInstance() as test_app:
+            # Configure the server with 3 workers
+            test_app.process.kwargs["workers"] = 3
+            test_app.process.start()
+            # Verify that the server is running
+            self.assertTrue(test_app.process.ready.wait(test_app.startup_timeout))

--- a/tests/http_base.py
+++ b/tests/http_base.py
@@ -290,6 +290,5 @@ class DaphneTestCase(unittest.TestCase):
         with DaphneTestingInstance() as test_app:
             # Configure the server with 3 workers
             test_app.process.kwargs["workers"] = 3
-            test_app.process.start()
             # Verify that the server is running
             self.assertTrue(test_app.process.ready.wait(test_app.startup_timeout))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -257,6 +257,18 @@ class TestCLIInterface(TestCase):
         """
         self.assertCLI(["--no-server-name"], {"server_name": ""})
 
+    def test_workers_default(self):
+        """
+        Tests that the default number of workers is 1.
+        """
+        self.assertCLI([], {"workers": 1})
+
+    def test_workers_custom(self):
+        """
+        Tests that the CLI correctly parses the --workers argument.
+        """
+        self.assertCLI(["--workers", "4"], {"workers": 4})
+
 
 @skipUnless(os.getenv("ASGI_THREADS"), "ASGI_THREADS environment variable not set.")
 class TestASGIThreads(TestCase):


### PR DESCRIPTION
This pull request introduces support for running the Daphne server with multiple worker processes, improving scalability and performance. Key changes include the addition of a `--workers` argument to the CLI and management commands, updates to the server implementation to handle worker processes, and new tests to ensure the functionality works as expected.

### Feature: Worker Process Support

* [`daphne/cli.py`](diffhunk://#diff-e7d2146031731798dded96cd276438c0182797761a3374236d7d04ece34ef79aR163-R169): Added a `--workers` argument to the CLI to specify the number of worker processes (default: 1). Updated `run` method to pass the `workers` value to the server. [[1]](diffhunk://#diff-e7d2146031731798dded96cd276438c0182797761a3374236d7d04ece34ef79aR163-R169) [[2]](diffhunk://#diff-e7d2146031731798dded96cd276438c0182797761a3374236d7d04ece34ef79aR297)
* [`daphne/management/commands/runserver.py`](diffhunk://#diff-b77805c7a925d67206a8d0331f25dec64cde64bacec3218c16d4ac9f0a8a0f0cR88-R95): Added a `--workers` argument to the `runserver` management command and passed the value to the server in `inner_run`. [[1]](diffhunk://#diff-b77805c7a925d67206a8d0331f25dec64cde64bacec3218c16d4ac9f0a8a0f0cR88-R95) [[2]](diffhunk://#diff-b77805c7a925d67206a8d0331f25dec64cde64bacec3218c16d4ac9f0a8a0f0cR155)

### Implementation: Server Updates for Worker Processes

* [`daphne/server.py`](diffhunk://#diff-5b8dd1c1fb553c31eaba229ba00feeb4e69c6e653a4ae00f8769e53da8e131d8R6): Introduced a `workers` parameter to the server's constructor. Implemented worker process management using `multiprocessing`, with a `_run_worker` method to start the server in each worker process. [[1]](diffhunk://#diff-5b8dd1c1fb553c31eaba229ba00feeb4e69c6e653a4ae00f8769e53da8e131d8R6) [[2]](diffhunk://#diff-5b8dd1c1fb553c31eaba229ba00feeb4e69c6e653a4ae00f8769e53da8e131d8R70) [[3]](diffhunk://#diff-5b8dd1c1fb553c31eaba229ba00feeb4e69c6e653a4ae00f8769e53da8e131d8R94-R95) [[4]](diffhunk://#diff-5b8dd1c1fb553c31eaba229ba00feeb4e69c6e653a4ae00f8769e53da8e131d8L149-R172)

### Testing: Validation of Worker Functionality

* [`tests/http_base.py`](diffhunk://#diff-c267df79f55044a28d9816699ebc63ff4d109d59fb7916dba2f0dfb4972cb4f4R285-R295): Added a `test_multiple_workers` test to verify that the server can start with multiple workers.
* [`tests/test_cli.py`](diffhunk://#diff-4e8715c7a425ee52e74b7df4d34efd32e8c92f3e60bd51bc2e1ad5943b82032eR260-R271): Added tests to ensure the CLI correctly parses the `--workers` argument and uses the default value of 1 when not specified.