### PR TITLE
Remove --nostatic and --insecure args to runserver command if staticfiles app is not installed.

### DIFF
--- a/daphne/management/commands/runserver.py
+++ b/daphne/management/commands/runserver.py
@@ -73,18 +73,19 @@ class Command(RunserverCommand):
                 "seconds (default: 5)"
             ),
         )
-        parser.add_argument(
-            "--nostatic",
-            action="store_false",
-            dest="use_static_handler",
-            help="Tells Django to NOT automatically serve static files at STATIC_URL.",
-        )
-        parser.add_argument(
-            "--insecure",
-            action="store_true",
-            dest="insecure_serving",
-            help="Allows serving static files even if DEBUG is False.",
-        )
+        if apps.is_installed("django.contrib.staticfiles"):
+            parser.add_argument(
+                "--nostatic",
+                action="store_false",
+                dest="use_static_handler",
+                help="Tells Django to NOT automatically serve static files at STATIC_URL.",
+            )
+            parser.add_argument(
+                "--insecure",
+                action="store_true",
+                dest="insecure_serving",
+                help="Allows serving static files even if DEBUG is False.",
+            )
 
     def handle(self, *args, **options):
         self.http_timeout = options.get("http_timeout", None)


### PR DESCRIPTION
Fixes #558 