### PR TITLE
Refactor endpoint parsing for better extensibility

### DIFF
--- a/daphne/endpoints.py
+++ b/daphne/endpoints.py
@@ -1,9 +1,11 @@
 from abc import ABC, abstractmethod
 
+
 class Endpoint(ABC):
     @abstractmethod
     def parse(self, options):
         pass
+
 
 class TCPEndpoint(Endpoint):
     def parse(self, options):
@@ -14,11 +16,13 @@ class TCPEndpoint(Endpoint):
             raise ValueError("TCP binding requires both port and host kwargs.")
         return None
 
+
 class UNIXEndpoint(Endpoint):
     def parse(self, options):
         if options.get("unix_socket"):
             return f"unix:{options['unix_socket']}"
         return None
+
 
 class FileDescriptorEndpoint(Endpoint):
     def parse(self, options):
@@ -26,7 +30,9 @@ class FileDescriptorEndpoint(Endpoint):
             return f"fd:fileno={int(options['file_descriptor'])}"
         return None
 
+
 endpoint_parsers = [TCPEndpoint(), UNIXEndpoint(), FileDescriptorEndpoint()]
+
 
 def build_endpoint_description_strings(**kwargs):
     """

--- a/daphne/endpoints.py
+++ b/daphne/endpoints.py
@@ -1,22 +1,42 @@
-def build_endpoint_description_strings(
-    host=None, port=None, unix_socket=None, file_descriptor=None
-):
+from abc import ABC, abstractmethod
+
+class Endpoint(ABC):
+    @abstractmethod
+    def parse(self, options):
+        pass
+
+class TCPEndpoint(Endpoint):
+    def parse(self, options):
+        if options.get("port") and options.get("host"):
+            host = options["host"].strip("[]").replace(":", r"\:")
+            return f"tcp:port={int(options['port'])}:interface={host}"
+        elif options.get("port") or options.get("host"):
+            raise ValueError("TCP binding requires both port and host kwargs.")
+        return None
+
+class UNIXEndpoint(Endpoint):
+    def parse(self, options):
+        if options.get("unix_socket"):
+            return f"unix:{options['unix_socket']}"
+        return None
+
+class FileDescriptorEndpoint(Endpoint):
+    def parse(self, options):
+        if options.get("file_descriptor") is not None:
+            return f"fd:fileno={int(options['file_descriptor'])}"
+        return None
+
+endpoint_parsers = [TCPEndpoint(), UNIXEndpoint(), FileDescriptorEndpoint()]
+
+def build_endpoint_description_strings(**kwargs):
     """
     Build a list of twisted endpoint description strings that the server will listen on.
     This is to streamline the generation of twisted endpoint description strings from easier
     to use command line args such as host, port, unix sockets etc.
     """
     socket_descriptions = []
-    if host and port is not None:
-        host = host.strip("[]").replace(":", r"\:")
-        socket_descriptions.append("tcp:port=%d:interface=%s" % (int(port), host))
-    elif any([host, port]):
-        raise ValueError("TCP binding requires both port and host kwargs.")
-
-    if unix_socket:
-        socket_descriptions.append("unix:%s" % unix_socket)
-
-    if file_descriptor is not None:
-        socket_descriptions.append("fd:fileno=%d" % int(file_descriptor))
-
+    for parser in endpoint_parsers:
+        description = parser.parse(kwargs)
+        if description:
+            socket_descriptions.append(description)
     return socket_descriptions

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,9 +5,11 @@ from unittest import TestCase, skipUnless
 
 from daphne.cli import CommandLineInterface
 from daphne.endpoints import (
-    build_endpoint_description_strings as build,
-    endpoint_parsers,
     Endpoint,
+)
+from daphne.endpoints import build_endpoint_description_strings as build
+from daphne.endpoints import (
+    endpoint_parsers,
 )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,11 @@ from argparse import ArgumentError
 from unittest import TestCase, skipUnless
 
 from daphne.cli import CommandLineInterface
-from daphne.endpoints import build_endpoint_description_strings as build
+from daphne.endpoints import (
+    build_endpoint_description_strings as build,
+    endpoint_parsers,
+    Endpoint,
+)
 
 
 class TestEndpointDescriptions(TestCase):
@@ -63,6 +67,23 @@ class TestEndpointDescriptions(TestCase):
                 ]
             ),
         )
+
+    def test_custom_endpoint(self):
+        class CustomEndpoint(Endpoint):
+            def parse(self, options):
+                if options.get("custom"):
+                    return f"custom:{options['custom']}"
+                return None
+
+        endpoint_parsers.append(CustomEndpoint())
+
+        self.assertEqual(
+            build(custom="myprotocol"),
+            ["custom:myprotocol"],
+        )
+
+        # Cleanup custom endpoint parser
+        endpoint_parsers.pop()
 
 
 class TestCLIInterface(TestCase):


### PR DESCRIPTION
Hey team,

I've been looking at how we handle endpoint parsing, and I saw an opportunity to make it more flexible and easier to extend. This PR refactors the endpoint handling logic to be more modular, which should make it easier for us and other developers to add custom endpoint types in the future.

#### What's new?

- **Modular endpoint parsing**: I've introduced an abstract base class for endpoints in `daphne/endpoints.py` and created concrete classes for TCP, UNIX, and File Descriptor endpoints. This makes the code cleaner and opens the door for custom endpoint parsers.
- **Updated tests**: The CLI tests in `tests/test_cli.py` have been updated to work with the new modular design. I've also added a new test case to show how a custom endpoint parser can be added and used.

This change doesn't alter any existing functionality, but it makes the codebase more robust and extensible for future development. I think this will be a great improvement for anyone looking to use Daphne in more advanced setups.

Let me know what you think!