### PR TITLE
Exit runserver when Daphne startup aborts

### DIFF
--- a/daphne/http_protocol.py
+++ b/daphne/http_protocol.py
@@ -77,9 +77,7 @@ class WebRequest(http.Request):
                     return
                 for value in values:
                     if INVALID_HEADER_VALUE_BYTES.intersection(value):
-                        self.basic_error(
-                            400, b"Bad Request", "Invalid header value"
-                        )
+                        self.basic_error(400, b"Bad Request", "Invalid header value")
                         return
 
             # Get upgrade header

--- a/daphne/management/commands/runserver.py
+++ b/daphne/management/commands/runserver.py
@@ -136,16 +136,27 @@ class Command(RunserverCommand):
 
         # build the endpoint description string from host/port options
         endpoints = build_endpoint_description_strings(host=self.addr, port=self.port)
+        self.run_daphne(
+            application=self.get_application(options),
+            endpoints=endpoints,
+            options=options,
+            root_path=getattr(settings, "FORCE_SCRIPT_NAME", "") or "",
+        )
+
+    def run_daphne(self, application, endpoints, options, root_path):
         try:
-            self.server_cls(
-                application=self.get_application(options),
+            self.server = self.server_cls(
+                application=application,
                 endpoints=endpoints,
                 signal_handlers=not options["use_reloader"],
                 action_logger=self.log_action,
                 http_timeout=self.http_timeout,
-                root_path=getattr(settings, "FORCE_SCRIPT_NAME", "") or "",
+                root_path=root_path,
                 websocket_handshake_timeout=self.websocket_handshake_timeout,
-            ).run()
+            )
+            self.server.run()
+            if self.server.abort_start:
+                raise CommandError("Daphne failed to start.")
             logger.debug("Daphne exited")
         except KeyboardInterrupt:
             shutdown_message = options.get("shutdown_message", "")

--- a/tests/test_runserver_startup.py
+++ b/tests/test_runserver_startup.py
@@ -1,0 +1,34 @@
+from unittest import TestCase
+
+from django.core.management import CommandError
+
+from daphne.management.commands.runserver import Command
+
+
+class TestRunserverCommand(TestCase):
+    class AbortedServer:
+        abort_start = True
+
+        def __init__(self, **kwargs):
+            self.init_kwargs = kwargs
+            self.ran = False
+
+        def run(self):
+            self.ran = True
+
+    def test_run_daphne_raises_command_error_when_start_aborts(self):
+        command = Command()
+        command.server_cls = self.AbortedServer
+        command.http_timeout = None
+        command.websocket_handshake_timeout = 5
+
+        with self.assertRaisesRegex(CommandError, "Daphne failed to start."):
+            command.run_daphne(
+                application=object(),
+                endpoints=["tcp:port=8000:interface=127.0.0.1"],
+                options={"use_reloader": False},
+                root_path="",
+            )
+
+        self.assertTrue(command.server.ran)
+        self.assertTrue(command.server.init_kwargs["signal_handlers"])

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -330,9 +330,7 @@ class TestWebsocket(DaphneTestCase):
             sock, _ = self.websocket_handshake(test_app)
             _, messages = test_app.get_received()
             self.assert_valid_websocket_connect_message(messages[0])
-            test_app.add_send_messages(
-                [{"type": "websocket.send", "text": "ack"}]
-            )
+            test_app.add_send_messages([{"type": "websocket.send", "text": "ack"}])
             self.websocket_send_frame(sock, "x" * 16)
             assert self.websocket_receive_frame(sock) == "ack"
 
@@ -418,9 +416,7 @@ class TestHeaderValueInjection(DaphneTestCase):
         for byte in self.INVALID_BYTES:
             with self.subTest(byte=byte):
                 value = b"innocent" + byte + b"X-Secret-Auth: admin-token"
-                response = self.run_daphne_raw(
-                    self._websocket_upgrade_request(value)
-                )
+                response = self.run_daphne_raw(self._websocket_upgrade_request(value))
                 self.assertTrue(
                     response.startswith(b"HTTP/1.1 400"),
                     f"expected 400 for byte {byte!r}, got {response[:80]!r}",


### PR DESCRIPTION
## Summary

- make the Django `runserver` command check `Server.abort_start` after `Server.run()` returns
- raise `CommandError` when Daphne aborts during startup, matching the standalone CLI behavior of exiting non-zero
- add a focused runserver startup test that simulates an abort from the server

Fixes #577

## Tests

- `python -m pytest tests\test_runserver_startup.py tests\test_cli.py -q`
- `python -m pytest -q tests --ignore=tests/test_packaging.py`
- `python -m black --check daphne\management\commands\runserver.py tests\test_runserver_startup.py`
- `python -m flake8 daphne\management\commands\runserver.py tests\test_runserver_startup.py`
- `git diff --check`

Note: `python -m pytest -q` fails in my local editable-install environment only at `tests/test_packaging.py::test_fd_endpoint_plugin_installed`, because the Twisted plugin file is not present under the selected `site-packages` path. The runtime tests pass with that packaging-only test excluded.