### PR TITLE
Format runserver access logs before logging

### DIFF
--- a/daphne/http_protocol.py
+++ b/daphne/http_protocol.py
@@ -77,9 +77,7 @@ class WebRequest(http.Request):
                     return
                 for value in values:
                     if INVALID_HEADER_VALUE_BYTES.intersection(value):
-                        self.basic_error(
-                            400, b"Bad Request", "Invalid header value"
-                        )
+                        self.basic_error(400, b"Bad Request", "Invalid header value")
                         return
 
             # Get upgrade header

--- a/daphne/management/commands/runserver.py
+++ b/daphne/management/commands/runserver.py
@@ -178,27 +178,27 @@ class Command(RunserverCommand):
             # Utilize terminal colors, if available
             if 200 <= details["status"] < 300:
                 # Put 2XX first, since it should be the common case
-                logger.info(self.style.HTTP_SUCCESS(msg), details)
+                logger.info(self.style.HTTP_SUCCESS(msg) % details)
             elif 100 <= details["status"] < 200:
-                logger.info(self.style.HTTP_INFO(msg), details)
+                logger.info(self.style.HTTP_INFO(msg) % details)
             elif details["status"] == 304:
-                logger.info(self.style.HTTP_NOT_MODIFIED(msg), details)
+                logger.info(self.style.HTTP_NOT_MODIFIED(msg) % details)
             elif 300 <= details["status"] < 400:
-                logger.info(self.style.HTTP_REDIRECT(msg), details)
+                logger.info(self.style.HTTP_REDIRECT(msg) % details)
             elif details["status"] == 404:
-                logger.warning(self.style.HTTP_NOT_FOUND(msg), details)
+                logger.warning(self.style.HTTP_NOT_FOUND(msg) % details)
             elif 400 <= details["status"] < 500:
-                logger.warning(self.style.HTTP_BAD_REQUEST(msg), details)
+                logger.warning(self.style.HTTP_BAD_REQUEST(msg) % details)
             else:
                 # Any 5XX, or any other response
-                logger.error(self.style.HTTP_SERVER_ERROR(msg), details)
+                logger.error(self.style.HTTP_SERVER_ERROR(msg) % details)
 
         # Websocket requests
         elif protocol == "websocket" and action == "connected":
-            logger.info("WebSocket CONNECT %(path)s [%(client)s]", details)
+            logger.info("WebSocket CONNECT %(path)s [%(client)s]" % details)
         elif protocol == "websocket" and action == "disconnected":
-            logger.info("WebSocket DISCONNECT %(path)s [%(client)s]", details)
+            logger.info("WebSocket DISCONNECT %(path)s [%(client)s]" % details)
         elif protocol == "websocket" and action == "connecting":
-            logger.info("WebSocket HANDSHAKING %(path)s [%(client)s]", details)
+            logger.info("WebSocket HANDSHAKING %(path)s [%(client)s]" % details)
         elif protocol == "websocket" and action == "rejected":
-            logger.info("WebSocket REJECT %(path)s [%(client)s]", details)
+            logger.info("WebSocket REJECT %(path)s [%(client)s]" % details)

--- a/tests/test_runserver.py
+++ b/tests/test_runserver.py
@@ -1,0 +1,26 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from daphne.management.commands.runserver import Command
+
+
+class TestRunserverCommand(TestCase):
+    def test_log_action_formats_http_details_before_logging(self):
+        command = Command()
+        details = {
+            "method": "GET",
+            "path": "/example/",
+            "status": 200,
+            "time_taken": 0.01,
+            "client": "127.0.0.1:8000",
+            "size": 0,
+        }
+
+        with patch("daphne.management.commands.runserver.logger.info") as mock_info:
+            command.log_action("http", "complete", details)
+
+        mock_info.assert_called_once()
+        args, kwargs = mock_info.call_args
+        self.assertEqual(len(args), 1)
+        self.assertEqual(kwargs, {})
+        self.assertIn("HTTP GET /example/ 200 [0.01, 127.0.0.1:8000]", args[0])

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -330,9 +330,7 @@ class TestWebsocket(DaphneTestCase):
             sock, _ = self.websocket_handshake(test_app)
             _, messages = test_app.get_received()
             self.assert_valid_websocket_connect_message(messages[0])
-            test_app.add_send_messages(
-                [{"type": "websocket.send", "text": "ack"}]
-            )
+            test_app.add_send_messages([{"type": "websocket.send", "text": "ack"}])
             self.websocket_send_frame(sock, "x" * 16)
             assert self.websocket_receive_frame(sock) == "ack"
 
@@ -418,9 +416,7 @@ class TestHeaderValueInjection(DaphneTestCase):
         for byte in self.INVALID_BYTES:
             with self.subTest(byte=byte):
                 value = b"innocent" + byte + b"X-Secret-Auth: admin-token"
-                response = self.run_daphne_raw(
-                    self._websocket_upgrade_request(value)
-                )
+                response = self.run_daphne_raw(self._websocket_upgrade_request(value))
                 self.assertTrue(
                     response.startswith(b"HTTP/1.1 400"),
                     f"expected 400 for byte {byte!r}, got {response[:80]!r}",


### PR DESCRIPTION
## Summary

- format runserver access-log messages with their details before passing them to the logger
- apply the same pattern to HTTP and WebSocket runserver log messages
- add a regression test that verifies the logger receives a single formatted message instead of a message plus `details` as a second positional argument

Fixes #576

## Tests

- `python -m pytest tests\test_runserver.py tests\test_cli.py -q`
- `python -m pytest -q tests --ignore=tests/test_packaging.py`
- `python -m black --check daphne\management\commands\runserver.py tests\test_runserver.py`
- `python -m flake8 daphne\management\commands\runserver.py tests\test_runserver.py`
- `git diff --check`

Note: as in #583, `python -m pytest -q` fails in my local editable-install environment only at `tests/test_packaging.py::test_fd_endpoint_plugin_installed`, because the Twisted plugin file is not present under the selected `site-packages` path. The runtime tests pass with that packaging-only test excluded.